### PR TITLE
Add padding to BoxTextInput input

### DIFF
--- a/src/components/BoxTextInput/styles.css
+++ b/src/components/BoxTextInput/styles.css
@@ -9,6 +9,7 @@
   transition: all 0.25s;
   line-height: var(--spacing-2);
   padding: 1rem 2rem;
+  padding-right: 4rem;
   margin-top: 1.2rem;
 }
 
@@ -48,7 +49,7 @@
   position: absolute;
   font-size: inherit;
   background: none !important;
-  right: 2rem;
+  right: 1rem;
   top: calc(50% - 0.5rem);
   transform: translate(-50%, -50%);
   user-select: none;


### PR DESCRIPTION
This is necessary so that big length inputs don't overflow the search icon space.