### PR TITLE
Add markerTooltipText props to the status bar component

### DIFF
--- a/src/components/StatusBar/StatusBar.jsx
+++ b/src/components/StatusBar/StatusBar.jsx
@@ -7,6 +7,8 @@ import Tooltip from "../Tooltip/Tooltip.jsx";
 const StatusBar = ({
   status,
   markerPosition,
+  markerTooltipText,
+  markerTooltipClassName,
   max,
   showMarker,
   renderStatusInfoComponent,
@@ -75,7 +77,10 @@ const StatusBar = ({
             style={{
               left: markerPosition
             }}>
-            <Tooltip content={markerPosition} className={styles.markerTooltip}>
+            <Tooltip
+              content={markerTooltipText || markerPosition}
+              className={styles.markerTooltip}
+              contentClassName={markerTooltipClassName}>
               <div className={styles.marker} />
             </Tooltip>
           </div>
@@ -100,6 +105,8 @@ DefaultInfoComp.propTypes = {
 StatusBar.propTypes = {
   status: PropTypes.array.isRequired,
   markerPosition: PropTypes.string,
+  markerTooltipText: PropTypes.string,
+  markerTooltipClassName: PropTypes.string,
   renderStatusInfoComponent: PropTypes.element,
   max: PropTypes.number,
   showMarker: PropTypes.bool,

--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -3,10 +3,22 @@ import PropTypes from "prop-types";
 import styles from "./styles.css";
 import { classNames } from "../../utils";
 
-const Tooltip = ({ children, content, placement, className, ...props }) => {
+const Tooltip = ({
+  children,
+  content,
+  placement,
+  className,
+  contentClassName,
+  ...props
+}) => {
   return (
     <div className={classNames(styles.tooltip, className)} {...props}>
-      <div className={classNames(styles.tooltipContent, styles[placement])}>
+      <div
+        className={classNames(
+          styles.tooltipContent,
+          styles[placement],
+          contentClassName
+        )}>
         {content}
       </div>
       {children}
@@ -18,7 +30,8 @@ Tooltip.propTypes = {
   children: PropTypes.node.isRequired,
   placement: PropTypes.string,
   content: PropTypes.string,
-  className: PropTypes.string
+  className: PropTypes.string,
+  contentClassName: PropTypes.string
 };
 
 Tooltip.defaultProps = {

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -29,6 +29,10 @@ a:visited {
   top: 20px;
 }
 
+.statusBarMarkerTooltipExample {
+  width: 225px;
+}
+
 .dropdownCustomListExample {
   margin-top: 4.5rem !important;
 }

--- a/src/docs/statusbar.mdx
+++ b/src/docs/statusbar.mdx
@@ -6,6 +6,8 @@ route: /components/statusbar
 
 import { Playground, Props } from "docz";
 import { StatusBar } from "../index";
+import styles from "../css/base.css";
+import { classNames } from "../utils";
 
 # StatusBar
 
@@ -35,6 +37,8 @@ import { StatusBar } from "../index";
       }
     ]}
     markerPosition = "50%"
+    markerTooltipText = "60% Yes votes required for approval"
+    markerTooltipClassName={classNames(styles.statusBarMarkerTooltipExample)}
     max={5000}
   />
   <br/>

--- a/src/docs/statusbar.mdx
+++ b/src/docs/statusbar.mdx
@@ -37,7 +37,7 @@ import { classNames } from "../utils";
       }
     ]}
     markerPosition = "50%"
-    markerTooltipText = "60% Yes votes required for approval"
+    markerTooltipText = "50% Yes votes required for approval"
     markerTooltipClassName={classNames(styles.statusBarMarkerTooltipExample)}
     max={5000}
   />


### PR DESCRIPTION
We needed a new props to be able to pass custom marker/tooltip text to the status bar component as input in order to implement https://github.com/decred/politeiagui/issues/1557