### PR TITLE
Layout example app: fix link in docs & styling issue

### DIFF
--- a/examples/layout/src/index.js
+++ b/examples/layout/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
+import "pi-ui/dist/index.css";
 
 ReactDOM.render(<App />, document.getElementById('root'));
 

--- a/src/docs/layout.mdx
+++ b/src/docs/layout.mdx
@@ -68,4 +68,4 @@ Sidebar goes from `col-start 9` to `center-end` and occupies the fourth row of t
 
 ## Example
 
-Take a look at the [example app](https://github.com/tiagoalvesdulce/pi-ui/tree/master/examples/layout).
+Take a look at the [example app](https://github.com/decred/pi-ui/tree/master/examples/layout).


### PR DESCRIPTION
Layout example app link still leading to old repo:

![image](https://user-images.githubusercontent.com/10324528/68508046-a324a500-026d-11ea-962b-56ac98b0728e.png)
