### PR TITLE
Container: fix zero height inputs

### DIFF
--- a/src/components/Layout/Container.jsx
+++ b/src/components/Layout/Container.jsx
@@ -14,11 +14,11 @@ const Container = ({
   ...props
 }) => {
   const topBannerRowHeight =
-    typeof topBannerHeight !== "undefined" ? `${topBannerHeight}px` : "14rem";
+    topBannerHeight !== null ? `${topBannerHeight}px` : "14rem";
   const headerRowHeight =
-    typeof headerHeight !== "undefined" ? `${headerHeight}px` : "6rem";
+    topBannerHeight !== null ? `${headerHeight}px` : "6rem";
   const mainAndBannerGapSize =
-    typeof bannerAndMainGap !== "undefined" ? `${bannerAndMainGap}px` : "3rem";
+    topBannerHeight !== null ? `${bannerAndMainGap}px` : "3rem";
   return (
     <div
       className={classNames(styles.container, className)}

--- a/src/components/Layout/Container.jsx
+++ b/src/components/Layout/Container.jsx
@@ -13,11 +13,12 @@ const Container = ({
   singleContent,
   ...props
 }) => {
-  const topBannerRowHeight = topBannerHeight ? `${topBannerHeight}px` : "14rem";
-  const headerRowHeight = headerHeight ? `${headerHeight}px` : "6rem";
-  const mainAndBannerGapSize = bannerAndMainGap
-    ? `${bannerAndMainGap}px`
-    : "3rem";
+  const topBannerRowHeight =
+    typeof topBannerHeight !== "undefined" ? `${topBannerHeight}px` : "14rem";
+  const headerRowHeight =
+    typeof headerHeight !== "undefined" ? `${headerHeight}px` : "6rem";
+  const mainAndBannerGapSize =
+    typeof bannerAndMainGap !== "undefined" ? `${bannerAndMainGap}px` : "3rem";
   return (
     <div
       className={classNames(styles.container, className)}


### PR DESCRIPTION
Providing height as 0 was causing an issue, and the reason was:
```
const topBannerRowHeight = topBannerHeight ? `${topBannerHeight}px` : "14rem";
```
Added an explicit check if `topBannerHeight` is null to handle the zero case properly. 