### PR TITLE
Fix error in useTrancate

### DIFF
--- a/src/hooks/useTruncate.js
+++ b/src/hooks/useTruncate.js
@@ -7,7 +7,7 @@ import lineClamp from "clamp-js-main";
  * @param {Object} styles
  * @param {Object} element
  */
-const setStylesOnElement = function (styles, element) {
+const setStylesOnElement = (styles, element) => {
   Object.assign(element.style, styles);
 };
 

--- a/src/hooks/useTruncate.js
+++ b/src/hooks/useTruncate.js
@@ -7,7 +7,7 @@ import lineClamp from "clamp-js-main";
  * @param {Object} styles
  * @param {Object} element
  */
-const setStylesOnElement = function(styles, element) {
+const setStylesOnElement = function (styles, element) {
   Object.assign(element.style, styles);
 };
 
@@ -38,21 +38,18 @@ const simpleClamp = (element) => {
  */
 
 const useTruncate = (elementID, truncate, linesBeforeTruncate) => {
-  useLayoutEffect(
-    function handleTruncate() {
-      if (truncate) {
-        const element = document.getElementById(elementID);
-        if (element) {
-          if (linesBeforeTruncate === 1) {
-            simpleClamp(element);
-          } else {
-            lineClamp(element, { clamp: linesBeforeTruncate });
-          }
+  useLayoutEffect(() => {
+    if (truncate) {
+      const element = document.getElementById(elementID);
+      if (element) {
+        if (linesBeforeTruncate === 1) {
+          simpleClamp(element);
+        } else {
+          lineClamp(element, { clamp: linesBeforeTruncate });
         }
       }
-    },
-    [truncate, linesBeforeTruncate]
-  );
+    }
+  }, [truncate, linesBeforeTruncate]);
 };
 
 export default useTruncate;

--- a/src/hooks/useTruncate.js
+++ b/src/hooks/useTruncate.js
@@ -1,5 +1,5 @@
 import { useLayoutEffect } from "react";
-import { clamp as lineClamp } from "clamp-js-main";
+import lineClamp from "clamp-js-main";
 
 /**
  * setStylesOnElement merges the provided styles with the target element
@@ -36,7 +36,8 @@ const simpleClamp = (element) => {
  * @param {Boolean} truncate
  * @param {number} linesBeforeTruncate
  */
-export default function useTruncate(elementID, truncate, linesBeforeTruncate) {
+
+const useTruncate = (elementID, truncate, linesBeforeTruncate) => {
   useLayoutEffect(
     function handleTruncate() {
       if (truncate) {
@@ -52,4 +53,6 @@ export default function useTruncate(elementID, truncate, linesBeforeTruncate) {
     },
     [truncate, linesBeforeTruncate]
   );
-}
+};
+
+export default useTruncate;


### PR DESCRIPTION
Typography docs page was throwing an error, tracked it and found out that the source is `useTrancate` hook, which was importing third-party lib wrongly. 

closes #190