### PR TITLE
css: set font-display on font-face.

### DIFF
--- a/src/theme/ThemeProvider.js
+++ b/src/theme/ThemeProvider.js
@@ -62,6 +62,7 @@ const applyFontAsset = (fontConfig, theme) => {
     format("${fontConfig.format}");
   font-weight: ${theme["font-weight-semi-bold"]};
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: ${fontConfig.fontFamilyText};
@@ -69,6 +70,7 @@ const applyFontAsset = (fontConfig, theme) => {
     format("${fontConfig.format}");
   font-weight: ${theme["font-weight-light"]};
   font-style: normal;
+  font-display: swap;
 }
 @font-face {
   font-family: ${fontConfig.fontFamilyText};
@@ -76,6 +78,7 @@ const applyFontAsset = (fontConfig, theme) => {
     format("${fontConfig.format}");
   font-weight: ${theme["font-weight-regular"]};
   font-style: normal;
+  font-display: swap;
 }
 `)
   );


### PR DESCRIPTION
This change sets font-display to swap to inform browsers to use
system fonts until the webfonts have downloaded.  This helps prevent
FOIT.