### PR TITLE
Select component dark theme colors

### DIFF
--- a/src/theme/darkTheme.js
+++ b/src/theme/darkTheme.js
@@ -45,6 +45,9 @@ const darkTheme = {
   "dropdown-item-hover-color": "#B7DEEE",
   "dropdown-arrow-color": "var(--text-color)",
 
+  "select-border-color": "var(--text-color)",
+  "select-anchor-color": "var(--text-color)",
+
   "copyable-text-background-color": "var(--container-color)",
 
   "modal-close-color": "var(--text-color)",

--- a/src/theme/lightTheme.js
+++ b/src/theme/lightTheme.js
@@ -162,7 +162,11 @@ const lightTheme = {
   "tooltip-background-color": "var(--color-white)",
 
   /** Checkbox */
-  "checkbox-stroke-color": "var(--color-gray)"
+  "checkbox-stroke-color": "var(--color-gray)",
+
+  /** Select */
+  "select-border-color": "var(--color-gray-lighter)",
+  "select-anchor-color": "var(--color-gray)"
 };
 
 export default lightTheme;


### PR DESCRIPTION
Part of https://github.com/decred/politeiagui/pull/1667.
Ideally we'd move select component implementation to `pi-ui` code base, instead of having the implementation in `pigui` and theme colors in `pi-ui`.

@tiagoalvesdulce  what do you think ? does it make sense to move it ? I could open an issue for that.