### PR TITLE
Change Proptype of the label prop in the tab component

### DIFF
--- a/src/components/Tabs/Tab.jsx
+++ b/src/components/Tabs/Tab.jsx
@@ -61,7 +61,7 @@ Tab.propTypes = {
   isActive: PropTypes.bool,
   className: PropTypes.string,
   style: PropTypes.object,
-  label: PropTypes.string,
+  label: PropTypes.node,
   count: PropTypes.node,
   mode: PropTypes.oneOf(["horizontal", "vertical", "dropdown"])
 };


### PR DESCRIPTION
This change clears a warning in pgui where we pass an anchor tag element as label but the component is expecting to receive a string.