### PR TITLE
ThemeProvider: Introduce fonts array property instead of limited fontConfig object

### DIFF
--- a/src/docs/theme.mdx
+++ b/src/docs/theme.mdx
@@ -20,7 +20,7 @@ export default {
 
 ## Use your theme in your application
 
-Pi-ui exposes a `ThemeProvider` that accepts a `themes` object, `defaultThemeName` as string and `fontConfig` object.
+Pi-ui exposes a `ThemeProvider` that accepts a `themes` object, `defaultThemeName` as string and `fonts` array.
 
 ```js
 import React from "react";
@@ -40,12 +40,40 @@ const fontConfig = {
   format: "truetype"
 };
 
+import SourceSansProLight from "src/assets/fonts/source-sans-pro/SourceSansPro-Light.ttf";
+import SourceSansProRegular from "src/assets/fonts/source-sans-pro/SourceSansPro-Regular.ttf";
+import SourceSansProSemiBold from "src/assets/fonts/source-sans-pro/SourceSansPro-SemiBold.ttf";
+
+const fonts = [
+  {
+    "font-family": "Source Sans Pro",
+    src: `url(${SourceSansProLight}) format("truetype")`,
+    "font-weight": defaultLightTheme["font-weight-light"], // 300
+    "font-style": "normal",
+    "font-display": "swap"
+  },
+  {
+    "font-family": "Source Sans Pro",
+    src: `url(${SourceSansProRegular}) format("truetype")`,
+    "font-weight": defaultLightTheme["font-weight-regular"], // 400
+    "font-style": "normal",
+    "font-display": "swap"
+  },
+  {
+    "font-family": "Source Sans Pro",
+    src: `url(${SourceSansProSemiBold}) format("truetype")`,
+    "font-weight": defaultLightTheme["font-weight-semi-bold"], // 600
+    "font-style": "normal",
+    "font-display": "swap"
+  }
+];
+
 const App = () => {
   return (
     <ThemeProvider
       themes={{ light: defaultLightTheme, customTheme }}
       defaultThemeName="customTheme"
-      fontConfig={fontConfig}>
+      fonts={fonts}>
       {children}
     </ThemeProvider>
   );

--- a/src/docs/theme.mdx
+++ b/src/docs/theme.mdx
@@ -32,18 +32,6 @@ import SourceSansProLight from "../assets/fonts/source-sans-pro/SourceSansPro-Li
 import SourceSansProRegular from "../assets/fonts/source-sans-pro/SourceSansPro-Regular.ttf";
 import SourceSansProSemiBold from "../assets/fonts/source-sans-pro/SourceSansPro-SemiBold.ttf";
 
-const fontConfig = {
-  fontFamilyText: "Source Sans Pro",
-  regularUrl: SourceSansProRegular,
-  semiBoldUrl: SourceSansProSemiBold,
-  lightUrl: SourceSansProLight,
-  format: "truetype"
-};
-
-import SourceSansProLight from "src/assets/fonts/source-sans-pro/SourceSansPro-Light.ttf";
-import SourceSansProRegular from "src/assets/fonts/source-sans-pro/SourceSansPro-Regular.ttf";
-import SourceSansProSemiBold from "src/assets/fonts/source-sans-pro/SourceSansPro-SemiBold.ttf";
-
 const fonts = [
   {
     "font-family": "Source Sans Pro",

--- a/src/theme/ThemeProvider.js
+++ b/src/theme/ThemeProvider.js
@@ -14,7 +14,7 @@ export const useTheme = () => useContext(ThemeContext);
 export const ThemeProvider = ({
   themes,
   defaultThemeName,
-  fontConfig,
+  fonts,
   children
 }) => {
   const [themeName, setThemeName] = useState(defaultThemeName);
@@ -23,10 +23,10 @@ export const ThemeProvider = ({
     Object.keys(theme).forEach((key) => {
       document.documentElement.style.setProperty(`--${key}`, theme[key]);
     });
-    if (fontConfig) {
-      applyFontAsset(fontConfig, theme);
+    if (fonts) {
+      applyFontAsset(fonts);
     }
-  }, [theme, fontConfig]);
+  }, [theme, fonts]);
 
   return (
     <ThemeContext.Provider
@@ -48,44 +48,27 @@ ThemeProvider.propTypes = {
       return new Error(`${propName} must match one of the given themes`);
     }
   },
-  fontConfig: PropTypes.object,
+  fonts: PropTypes.array,
   children: PropTypes.node
 };
 
-const applyFontAsset = (fontConfig, theme) => {
-  var newStyle = document.createElement("style");
-  newStyle.appendChild(
-    document.createTextNode(`
-@font-face {
-  font-family: ${fontConfig.fontFamilyText};
-  src: url(${fontConfig.semiBoldUrl})
-    format("${fontConfig.format}");
-  font-weight: ${theme["font-weight-semi-bold"]};
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: ${fontConfig.fontFamilyText};
-  src: url(${fontConfig.lightUrl})
-    format("${fontConfig.format}");
-  font-weight: ${theme["font-weight-light"]};
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: ${fontConfig.fontFamilyText};
-  src: url(${fontConfig.regularUrl})
-    format("${fontConfig.format}");
-  font-weight: ${theme["font-weight-regular"]};
-  font-style: normal;
-  font-display: swap;
-}
-`)
-  );
+const applyFontAsset = (fonts) => {
+  const newStyle = document.createElement("style");
+  fonts.forEach((fontFace) => {
+    let fontFaceStr = "";
+    for (const [key, value] of Object.entries(fontFace)) {
+      fontFaceStr = `${fontFaceStr}
+        ${key}: ${value}
+      `;
+    }
+    const fontFaceNode = document.createTextNode(`
+    @font-face {
+      ${fontFaceStr}
+    }
+    `);
+    newStyle.appendChild(fontFaceNode);
+  });
   newStyle.type = "text/css";
+  console.log(newStyle);
   document.head.appendChild(newStyle);
-  document.documentElement.style.setProperty(
-    "--font-family-text",
-    fontConfig.fontFamilyText
-  );
 };

--- a/src/theme/ThemeProvider.js
+++ b/src/theme/ThemeProvider.js
@@ -58,7 +58,7 @@ const applyFontAsset = (fonts) => {
     let fontFaceStr = "";
     for (const [key, value] of Object.entries(fontFace)) {
       fontFaceStr = `${fontFaceStr}
-        ${key}: ${value}
+        ${key}: ${value};
       `;
     }
     const fontFaceNode = document.createTextNode(`
@@ -69,6 +69,5 @@ const applyFontAsset = (fonts) => {
     newStyle.appendChild(fontFaceNode);
   });
   newStyle.type = "text/css";
-  console.log(newStyle);
   document.head.appendChild(newStyle);
 };


### PR DESCRIPTION
Lately we started with integrating pi-ui into decrediton and we are using `ThemeProvider` to provide it's themes variables and we would like to provide the fonts using `ThemeProvider`.

Before this diff we used to provider fontConfig from `pigui` using the following object:
```
const fontConfig = {
  fontFamilyText: "Source Sans Pro",
  regularUrl: SourceSansProRegular,
  semiBoldUrl: SourceSansProSemiBold,
  lightUrl: SourceSansProLight,
  format: "truetype"
};
```
The above object is pretty limiting in case we have multiple fonts which is the case in decrediton. 
In order to make it as generic as possible I've replaced `fontConfig` object with `fonts` array which should look something similar to:
```
const fonts = [
  {
    "font-family": "Source Sans Pro",
    src: `url(${SourceSansProLight}) format("truetype")`,
    "font-weight": defaultLightTheme["font-weight-light"],
    "font-style": "normal",
    "font-display": "swap"
  },
  {
    "font-family": "Source Sans Pro",
    src: `url(${SourceSansProRegular}) format("truetype")`,
    "font-weight": defaultLightTheme["font-weight-regular"],
    "font-style": "normal",
    "font-display": "swap"
  },
  {
    "font-family": "Source Sans Pro",
    src: `url(${SourceSansProSemiBold}) format("truetype")`,
    "font-weight": defaultLightTheme["font-weight-semi-bold"],
    "font-style": "normal",
    "font-display": "swap"
  }
];
```

With that we would be able to provide fonts arrays in `pigui` & `decrediton` without limiting the font configuration to some font-weight, or font-style!