### PR TITLE
DatePicker Improvements

### DIFF
--- a/src/components/Datepicker/Datepicker.jsx
+++ b/src/components/Datepicker/Datepicker.jsx
@@ -10,38 +10,51 @@ import Tappable from "react-tapper";
 import { classNames } from "../../utils";
 import styles from "./styles.css";
 import DatePickerPad from "./DatepickerPad.jsx";
-import { getYearArray, validValues, getYearsByNum, getDID } from "./helpers";
+import { useTheme } from "../../theme";
+import {
+  getYearArray,
+  validValues,
+  getYearsByNum,
+  getDID,
+  getInitialYears,
+  hasDateValueChanged,
+  getIndexByYear,
+  duplicateToArray,
+  makeLabelText
+} from "./helpers";
 
 const DatePicker = ({
-  range,
+  isRange,
   years,
   show,
   value,
   lang,
   className,
   children,
-  theme,
   onClickAway,
   onDismiss,
   onChange,
   onShow,
   onYearChange,
-  isMonthsMode,
-  enableAllMonths
+  isMonthsMode
 }) => {
+  const theme = useTheme();
+  const themeName = theme ? theme.themeName : "light";
   const yearArr = useMemo(() => getYearArray(years), [years]);
-  const yearIndexes = useMemo(() => [0], []);
-  const values = useMemo(
-    () => validValues(range || value, yearArr, yearIndexes),
-    [range, value, yearArr, yearIndexes]
-  );
+  const yearIndexes = useMemo(() => [0, 0], []);
+  const values = useMemo(() => validValues(value, yearArr, yearIndexes), [
+    value,
+    yearArr,
+    yearIndexes
+  ]);
+
+  const isDefaultPicker = useMemo(() => !children, [children]);
 
   const [yearsState] = useState(yearArr);
   const [valuesState, setValuesState] = useState(values);
-  const [labelYearsState, setLabelYearsState] = useState([
-    values[0] ? values[0].year : yearsState[0].year,
-    values[1] ? values[1].year : yearsState[0].year
-  ]);
+  const [labelYearsState, setLabelYearsState] = useState(
+    getInitialYears(values, yearsState)
+  );
   const [labelMonthsState, setLabelMonthsState] = useState([
     values[0] ? values[0].month : yearsState[0].min.month,
     values[1] ? values[1].month : yearsState[0].min.month
@@ -49,7 +62,6 @@ const DatePicker = ({
   const [showedState, setShowedState] = useState(show);
   const [yearIndexesState, setYearIndexesState] = useState(yearIndexes);
   const [pads, setPads] = useState([]);
-  const isRange = valuesState.length > 1;
 
   onDismiss = onDismiss || onChange;
 
@@ -57,14 +69,26 @@ const DatePicker = ({
     (e) => {
       const refid = getDID(e).split(":");
       const idx = parseInt(refid[0], 10);
-      const month = refid[1] !== "all" ? parseInt(refid[1], 10) : refid[1];
+      const month = parseInt(refid[1], 10);
       const year = labelYearsState[idx];
+      if (idx === 0) {
+        setLabelYearsState(duplicateToArray(year));
+        setYearIndexesState(duplicateToArray(yearIndexesState[0]));
+      }
       const values = [...valuesState];
       values[idx] = { year, month };
       setValuesState(values);
       onChange(year, month, idx);
     },
-    [labelYearsState, onChange, valuesState]
+    [
+      labelYearsState,
+      onChange,
+      valuesState,
+      setLabelYearsState,
+      setValuesState,
+      yearIndexesState,
+      setYearIndexesState
+    ]
   );
 
   const handleClickDay = useCallback(
@@ -192,7 +216,6 @@ const DatePicker = ({
           onNextYearClick={handleNextYearClick}
           onPrevMonthClick={handlePrevMonthClick}
           onNextMonthClick={handleNextMonthClick}
-          enableAllMonths={enableAllMonths}
         />
       );
     },
@@ -209,8 +232,7 @@ const DatePicker = ({
       labelYearsState,
       valuesState,
       yearIndexesState,
-      yearsState,
-      enableAllMonths
+      yearsState
     ]
   );
 
@@ -230,10 +252,33 @@ const DatePicker = ({
     if (show && !showedState) {
       setShowedState(true);
       onShow && onShow();
-    } else if (!show && showedState) {
+    } else if (!show && showedState && !isDefaultPicker) {
       setShowedState(false);
     }
-  }, [show, onShow, setShowedState, showedState]);
+  }, [show, onShow, setShowedState, showedState, isDefaultPicker]);
+
+  useEffect(
+    function onExternalValueChanges() {
+      if (hasDateValueChanged(values, valuesState)) {
+        const newIndexes = values.map((val) =>
+          getIndexByYear(val.year, yearArr)
+        );
+        const newLabels = values.map((y) => y.year);
+
+        setLabelYearsState(newLabels);
+        setYearIndexesState(newIndexes);
+        setValuesState(values);
+      }
+    },
+    [
+      values,
+      valuesState,
+      setValuesState,
+      setYearIndexesState,
+      setLabelYearsState,
+      yearArr
+    ]
+  );
 
   const getValue = useCallback(() => {
     const values = valuesState;
@@ -274,9 +319,27 @@ const DatePicker = ({
     }
   };
 
+  const defaultToggle = useCallback(() => {
+    setShowedState(!showedState);
+  }, [showedState, setShowedState]);
+
   return (
     <div className={classNames(styles.monthPicker, className)}>
       {children}
+      {!children && (
+        <span
+          onClick={defaultToggle}
+          className={styles.defaultDatepickerValueWrapper}>
+          {makeLabelText(values)}
+          <div
+            className={
+              showedState
+                ? styles.defaultDatepickerArrowOpen
+                : styles.defaultDatepickerArrow
+            }
+          />
+        </span>
+      )}
       <div
         className={classNames(
           styles.rmpContainer,
@@ -290,9 +353,8 @@ const DatePicker = ({
               styles.rmpPopup,
               isMonthsMode && styles.monthsMode,
               isRange && styles.range,
-              styles[theme],
-              showedState && styles.show,
-              enableAllMonths && styles.all
+              styles[themeName],
+              showedState && styles.show
             )}>
             {pads}
           </div>
@@ -308,18 +370,16 @@ DatePicker.propTypes = {
     PropTypes.object,
     PropTypes.number
   ]),
-  value: PropTypes.object,
-  range: PropTypes.object,
+  value: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+  isRange: PropTypes.bool,
   lang: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   onChange: PropTypes.func,
   onYearChange: PropTypes.func,
   onShow: PropTypes.func,
   onDismiss: PropTypes.func,
   onClickAway: PropTypes.func,
-  theme: PropTypes.string,
   show: PropTypes.bool,
   isMonthsMode: PropTypes.bool,
-  enableAllMonths: PropTypes.bool,
   className: PropTypes.string,
   children: PropTypes.node
 };
@@ -327,10 +387,9 @@ DatePicker.propTypes = {
 DatePicker.defaultProps = {
   years: getYearsByNum(5),
   onChange(year, month, idx) {},
-  theme: "light",
   show: false,
   isMonthsMode: false,
-  enableAllMonths: false
+  isRange: false
 };
 
 export default DatePicker;

--- a/src/components/Datepicker/Datepicker.jsx
+++ b/src/components/Datepicker/Datepicker.jsx
@@ -38,8 +38,7 @@ const DatePicker = ({
   onYearChange,
   isMonthsMode
 }) => {
-  const theme = useTheme();
-  const themeName = theme ? theme.themeName : "light";
+  const { themeName } = useTheme() || { themeName: "light" };
   const yearArr = useMemo(() => getYearArray(years), [years]);
   const yearIndexes = useMemo(() => [0, 0], []);
   const values = useMemo(() => validValues(value, yearArr, yearIndexes), [

--- a/src/components/Datepicker/DatepickerPad.jsx
+++ b/src/components/Datepicker/DatepickerPad.jsx
@@ -18,8 +18,7 @@ const DatePickerPad = ({
   onPrevMonthClick,
   onNextMonthClick,
   onMonthClick,
-  onDayClick,
-  enableAllMonths
+  onDayClick
 }) => {
   const value = values[padIndex];
   const ymArr = years;
@@ -57,8 +56,6 @@ const DatePickerPad = ({
     prevMonthCss = "disable";
   if (month === 12 || (atMaxYear && month === ymArr[yearMaxIdx].max.month))
     nextMonthCss = "disable";
-
-  const isAllOptionSelected = value && yearActive && value.month === "all";
 
   return (
     <div className={styles.rmpPad} key={padIndex}>
@@ -164,17 +161,6 @@ const DatePickerPad = ({
               </li>
             );
           })}
-        {isMonthsMode && enableAllMonths && (
-          <li
-            className={classNames(
-              styles.rmpBtn,
-              isAllOptionSelected && styles.select
-            )}
-            data-id={`${padIndex}:all`}
-            onClick={onMonthClick}>
-            All
-          </li>
-        )}
         {!isMonthsMode &&
           mapToArray(new Date(year, month, 0).getDate(), (i) => {
             let css = "";
@@ -226,7 +212,6 @@ DatePickerPad.propTypes = {
   years: PropTypes.array.isRequired,
   yearIdx: PropTypes.number.isRequired,
   isMonthsMode: PropTypes.bool,
-  enableAllMonths: PropTypes.bool,
   onPrevYearClick: PropTypes.func,
   onNextYearClick: PropTypes.func,
   onPrevMonthClick: PropTypes.func,

--- a/src/components/Datepicker/helpers.js
+++ b/src/components/Datepicker/helpers.js
@@ -1,3 +1,5 @@
+import isEmpty from "lodash/isEmpty";
+import _isEqual from "lodash/isEqual";
 const __MIN_VALID_YEAR = 1;
 
 export const mapToArray = (num, callback) => {
@@ -105,9 +107,9 @@ const validate = (d, years, idx, yearIndexes) => {
 
 export const validValues = (v, years, yearIndexes) => {
   if (!v) return [];
-  if (v.from || v.to) {
-    const from = validate(v.from, years, 0, yearIndexes);
-    const to = validate(v.to, years, 1, yearIndexes);
+  if (v[0] || v[1]) {
+    const from = validate(v[0], years, 0, yearIndexes);
+    const to = validate(v[1], years, 1, yearIndexes);
     if (
       from.year > to.year ||
       (from.year === to.year && from.month > to.month)
@@ -127,4 +129,49 @@ export const validValues = (v, years, yearIndexes) => {
 export const getDID = (e) => {
   const el = e.target;
   return el.dataset ? el.dataset.id : el.getAttribute("data-id");
+};
+
+export const duplicateToArray = (elem) => [elem, elem];
+
+export const getInitialYears = (values, yearsState) => {
+  if (!yearsState) return [];
+
+  const defaultYearValue = yearsState[0].year;
+
+  if (!values || isEmpty(values)) return duplicateToArray(defaultYearValue);
+
+  const firstYearSelected = values[0] && values[0].year;
+  const secondYearSelected = values[1] && values[1].year;
+
+  return firstYearSelected && secondYearSelected
+    ? [firstYearSelected, secondYearSelected]
+    : firstYearSelected && !secondYearSelected
+    ? duplicateToArray(firstYearSelected)
+    : duplicateToArray(defaultYearValue);
+};
+
+export const hasDateValueChanged = (newDate, prevDate) => {
+  return !_isEqual(newDate, prevDate);
+};
+
+export const getIndexByYear = (year, yearsArr) =>
+  yearsArr.reduce((acc, curr, index) => {
+    if (curr.year === year) return index;
+    return acc;
+  }, 0);
+
+export const makeLabelText = (values) => {
+  if (!values || !values.length) return "Pick a date";
+  function makeText(value) {
+    return value && value.year && value.month
+      ? `${value.day ? `${value.day}/` : ""}${value.month}/${value.year}`
+      : "";
+  }
+  const firstDateLabel = makeText(values[0]);
+  const secondDateLabel = makeText(values[1]);
+  return firstDateLabel === secondDateLabel
+    ? firstDateLabel
+    : secondDateLabel
+    ? `${firstDateLabel} - ${secondDateLabel}`
+    : firstDateLabel;
 };

--- a/src/components/Datepicker/styles.css
+++ b/src/components/Datepicker/styles.css
@@ -362,6 +362,11 @@
   .rmpPopup.light.range .rmpPad:first-of-type {
     border-top: 0;
   }
+
+  .rmpPopup.range {
+    bottom: 28rem;
+    height: 28.5rem;
+  }
 }
 
 @media screen and (min-width: 768px) {
@@ -401,4 +406,35 @@
   .rmpPopup.dark .rmpPad .rmpBtn:hover {
     background-color: rgba(255, 210, 96, 0.33);
   }
+}
+
+.defaultDatepickerArrow {
+  position: relative;
+  height: 100%;
+  width: 2rem;
+}
+
+.defaultDatepickerArrow:after {
+  content: "";
+  width: 0;
+  height: 0;
+  border: 0.5rem solid transparent;
+  border-color: var(--color-gray) transparent transparent transparent;
+  position: absolute;
+  top: 0.6rem;
+  right: 0.3rem;
+}
+
+.defaultDatepickerArrowOpen {
+  composes: defaultDatepickerArrow;
+}
+
+.defaultDatepickerArrowOpen:after {
+  top: 0.3rem;
+  border-color: transparent transparent var(--color-primary) transparent;
+}
+
+.defaultDatepickerValueWrapper {
+  cursor: pointer;
+  display: inline-flex;
 }

--- a/src/components/Datepicker/test/__snapshots__/datepicker.test.js.snap
+++ b/src/components/Datepicker/test/__snapshots__/datepicker.test.js.snap
@@ -4,6 +4,15 @@ exports[`DatePicker component Matches the snapshot 1`] = `
 <div
   className="monthPicker"
 >
+  <span
+    className="defaultDatepickerValueWrapper"
+    onClick={[Function]}
+  >
+    12/2020
+    <div
+      className="defaultDatepickerArrow"
+    />
+  </span>
   <div
     className="rmpContainer rmpTable"
   >

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -60,6 +60,7 @@ a:visited {
   height: 0;
   border: 0.5rem solid transparent;
   border-color: var(--color-gray) transparent transparent transparent;
+  color: var(--color-primary);
   position: absolute;
   top: 0.6rem;
   right: 0.3rem;

--- a/src/docs/datepicker.mdx
+++ b/src/docs/datepicker.mdx
@@ -16,27 +16,15 @@ import { DatePicker } from "../index";
 
 ## Usage
 
-### date picker
+### basic date picker
 
 <Playground>
   {() => {
-
-    const Arrow = ({ isOpen }) => {
-      return (
-        <div className={isOpen ? styles.exampledDatepickerArrowOpen : styles.exampledDatepickerArrow} />
-      );
-    };
-
     const [value, setValue] = useState({ year: 2019, month: 11, day: 15 });
-    const [isOpen, setIsOpen] = useState(false);
     const onChange = (year, month, day) => {
       if (!!year && !!month && !!day) {
         setValue({ year, month, day });
       }
-      setIsOpen(false);
-    };
-    const togglePicker = () => {
-      setIsOpen(!isOpen)
     };
 
     // provide `day` value for  min, max properties in years object to limit selection by day!
@@ -65,18 +53,15 @@ import { DatePicker } from "../index";
           ]}
           show={isOpen}
           onChange={onChange}
-        >
-          <span className={styles.exampledDatepickerValueWrapper} onClick={togglePicker}>
-            {`${value.day}/${value.month}/${value.year}`}
-            <Arrow isOpen={isOpen} />
-          </span>
-        </DatePicker>
+        />
       </Fragment>
     );
   }}
 </Playground>
 
-### month picker without default value
+### using a custom picker
+
+You can specify a **custom picker component**. If you go for this approach, don't forget to manually set the `isOpen` prop to `true` in order to effectively show your picker
 
 <Playground>
   {() => {
@@ -88,10 +73,11 @@ import { DatePicker } from "../index";
     };
 
     const [value, setValue] = useState(null);
+    // Manual control of  DatePicker's show prop
     const [isOpen, setIsOpen] = useState(false);
-    const onChange = (year, month) => {
-      if (!!year && !!month) {
-        setValue({ year, month });
+    const onChange = (year, month, day) => {
+      if (!!year && !!month && !!day) {
+        setValue({ year, month, day });
       }
       setIsOpen(false);
     };
@@ -110,45 +96,37 @@ import { DatePicker } from "../index";
           years={years} 
           value={value}
           show={isOpen}
-          isMonthsMode={true}
           onChange={onChange}
         >
+          {/* Custom picker component*/}
           <span className={styles.exampledDatepickerValueWrapper} onClick={togglePicker}>
-            {value && `${value.month}/${value.year}`}
-            {!value && "Pick a date"}
+            {value && `day ${value.day}, ${value.month} of ${value.year}`}
+            {!value && "Customized Date Picker"}
             <Arrow isOpen={isOpen} />
           </span>
+          {/**/}
         </DatePicker>
       </Fragment>
     );
   }}
 </Playground>
 
-### month picker with all months option
+
+
+### month picker
+
+You can also display **month options** instead of the default `days` view.
+
+Obs: the `onChange` function will not return the `day` value, obviously because it is not supposed to be shown. Instead, only `year` and `month` options are passed as parameters
 
 <Playground>
   {() => {
-
-    const Arrow = ({ isOpen }) => {
-      return (
-        <div className={isOpen ? styles.exampledDatepickerArrowOpen : styles.exampledDatepickerArrow} />
-      );
-    };
-
     const [value, setValue] = useState(null);
-    const [isOpen, setIsOpen] = useState(false);
     const onChange = (year, month) => {
       if (!!year && !!month) {
         setValue({ year, month });
       }
-      setIsOpen(false);
     };
-    const togglePicker = () => {
-      setIsOpen(!isOpen)
-    };
-
-    const isAllSelected = (value) => value.month === "all"
-
     // specify min, max properties in years object to limit selection
     const years = {
       min: { year: 2018, month: 1 },
@@ -159,18 +137,45 @@ import { DatePicker } from "../index";
       	<DatePicker
           years={years} 
           value={value}
-          show={isOpen}
+          // enable isMonthsMode prop
           isMonthsMode={true}
-          enableAllMonths={true}
           onChange={onChange}
-        >
-          <span className={styles.exampledDatepickerValueWrapper} onClick={togglePicker}>
-            {value && !isAllSelected(value) && `${value.month}/${value.year}`}
-            {value && isAllSelected(value) && `${value.year}`}
-            {!value && "Pick a date"}
-            <Arrow isOpen={isOpen} />
-          </span>
-        </DatePicker>
+        />
+      </Fragment>
+    );
+  }}
+</Playground>
+
+
+### month picker with range option
+
+To use the range option, just enable the `isRange` prop. In this case, `value` is treated as an array, where the first element is the initial range value, and the second is the last range value.
+
+
+<Playground>
+  {() => {
+    const initialValues = [
+      { year: 2019, month: 3 },
+      { year: 2020, month: 2 }
+    ]
+    const [values, setValues] = useState(initialValues);
+    const onChange = (year, month, idx) => {
+      if (!!year && !!month) {
+        const newValues = values ? [...values] : []
+        newValues[idx] = { year, month }
+        setValues(newValues);
+      }
+    };
+    // specify min, max properties in years object to limit selection
+    return (
+      <Fragment>
+      	<DatePicker
+          value={values}
+          isMonthsMode={true}
+          // enable isRange prop
+          isRange={true}
+          onChange={onChange}
+        />
       </Fragment>
     );
   }}


### PR DESCRIPTION
### Bug (or issue) description

As described on https://github.com/decred/politeiagui/issues/1888, the DatePicker component needed some improvements, to accept the correct range values.

### Solution description

The solution was to change the way the range is treated on our component. Now, you just need to pass the `value` prop as an Array, where indexes are the DatePicker's pad index, and toggle on the `isRange` prop.

Also, since the PR comprises the DatePicker scope, I decided to add a Default view for it, without needing to pass custom child components to show picker's label.

#### Use Cases (if needed)
Here is a quick example of how to use the DatePicker with the new range approach.
```javascript
() => {
// value as array
    const initialValues = [
      { year: 2019, month: 3 },
      { year: 2020, month: 2 }
    ]
    const [values, setValues] = useState(initialValues);

// idx is the pad index that triggered the onChange action
    const onChange = (year, month, idx) => {
      if (!!year && !!month) {
        const newValues = values ? [...values] : []
        newValues[idx] = { year, month }
        setValues(newValues);
      }
    };
    return (
      <Fragment>
      	<DatePicker
          value={values}
          isMonthsMode={true}
          // enable isRange prop
          isRange={true}
          onChange={onChange}
        />
      </Fragment>
    );
  }
```

### UI Changes Screenshot

![datepicker-improvements](https://user-images.githubusercontent.com/22639213/81345007-22186000-908e-11ea-85a2-1f8dc6d767b8.gif)

