### PR TITLE
Add 'clickArrow' icon & fix fonts in docz

### DIFF
--- a/src/components/Icon/Icon.jsx
+++ b/src/components/Icon/Icon.jsx
@@ -841,6 +841,13 @@ const icons = (type, backgroundColor, iconColor) => {
           transform="translate(-123.371 -123.37)"
         />
       </g>
+    ),
+    clickArrow: (
+      <path
+        fill={iconColor}
+        d="M715,138l5-5-5-5Z"
+        transform="translate(-715 -128)"
+      />
     )
   }[type];
 };

--- a/src/docs/Wrapper.js
+++ b/src/docs/Wrapper.js
@@ -6,20 +6,40 @@ import SourceSansProLight from "../assets/fonts/source-sans-pro/SourceSansPro-Li
 import SourceSansProRegular from "../assets/fonts/source-sans-pro/SourceSansPro-Regular.ttf";
 import SourceSansProSemiBold from "../assets/fonts/source-sans-pro/SourceSansPro-SemiBold.ttf";
 
-const fontConfig = {
-  fontFamilyText: "Source Sans Pro",
-  regularUrl: SourceSansProRegular,
-  semiBoldUrl: SourceSansProSemiBold,
-  lightUrl: SourceSansProLight,
-  format: "truetype"
+const themeCustomVariables = {
+  "font-family-text": "Source Sans Pro"
 };
+
+const fonts = [
+  {
+    "font-family": "Source Sans Pro",
+    src: `url(${SourceSansProLight}) format("truetype")`,
+    "font-weight": defaultLightTheme["font-weight-light"], // 300
+    "font-style": "normal",
+    "font-display": "swap"
+  },
+  {
+    "font-family": "Source Sans Pro",
+    src: `url(${SourceSansProRegular}) format("truetype")`,
+    "font-weight": defaultLightTheme["font-weight-regular"], // 400
+    "font-style": "normal",
+    "font-display": "swap"
+  },
+  {
+    "font-family": "Source Sans Pro",
+    src: `url(${SourceSansProSemiBold}) format("truetype")`,
+    "font-weight": defaultLightTheme["font-weight-semi-bold"], // 600
+    "font-style": "normal",
+    "font-display": "swap"
+  }
+];
 
 const DoczWrapper = ({ children }) => {
   return (
     <ThemeProvider
-      themes={{ light: defaultLightTheme }}
+      themes={{ light: { ...defaultLightTheme, ...themeCustomVariables } }}
       defaultThemeName="light"
-      fontConfig={fontConfig}>
+      fonts={fonts}>
       {children}
     </ThemeProvider>
   );

--- a/src/docs/icon.mdx
+++ b/src/docs/icon.mdx
@@ -49,6 +49,7 @@ import { Icon, IconWrapper } from "../index";
   <Icon type="info" />
   <Icon type="calendar" />
   <Icon type="horizontalLink" viewBox="0 0 24 16" width={24} height={16} />
+  <Icon type="clickArrow" viewBox="0 0 5 10" width={5} height={10} />
 </Playground>
 
 ## Sizes


### PR DESCRIPTION
Need for RFP submissions list items - see [specs](https://xd.adobe.com/view/44a3298e-a814-42b2-643e-3aa39c8dec34-3292/screen/63bdd388-0241-4bb8-ba18-985433ca7f90/RFP-description-page)
Also, it fixes fonts not being loaded after latest `ThemeProivder` changes.

Related to https://github.com/decred/politeiagui/pull/1910