### PR TITLE
Datepicker: map months to provided human readable values 

### DIFF
--- a/src/components/Datepicker/Datepicker.jsx
+++ b/src/components/Datepicker/Datepicker.jsx
@@ -329,7 +329,6 @@ DatePicker.defaultProps = {
   onChange(year, month, idx) {},
   theme: "light",
   show: false,
-  lang: [],
   isMonthsMode: false,
   enableAllMonths: false
 };

--- a/src/components/Datepicker/DatepickerPad.jsx
+++ b/src/components/Datepicker/DatepickerPad.jsx
@@ -30,7 +30,6 @@ const DatePickerPad = ({
       ? lang.months
       : null
     : null;
-  console.log(months);
   let prevCss = "";
   let prevMonthCss = "";
   let nextCss = "";

--- a/src/components/Datepicker/DatepickerPad.jsx
+++ b/src/components/Datepicker/DatepickerPad.jsx
@@ -23,11 +23,14 @@ const DatePickerPad = ({
 }) => {
   const value = values[padIndex];
   const ymArr = years;
-  const months = Array.isArray(lang)
-    ? lang
-    : Array.isArray(lang.months)
-    ? lang.months
-    : [];
+  const months = lang
+    ? Array.isArray(lang)
+      ? lang
+      : Array.isArray(lang.months)
+      ? lang.months
+      : null
+    : null;
+  console.log(months);
   let prevCss = "";
   let prevMonthCss = "";
   let nextCss = "";
@@ -218,7 +221,7 @@ const DatePickerPad = ({
 DatePickerPad.propTypes = {
   padIndex: PropTypes.number.isRequired,
   values: PropTypes.array.isRequired,
-  lang: PropTypes.oneOfType([PropTypes.array, PropTypes.object]).isRequired,
+  lang: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
   year: PropTypes.number.isRequired,
   month: PropTypes.number.isRequired,
   years: PropTypes.array.isRequired,

--- a/src/components/Datepicker/DatepickerPad.jsx
+++ b/src/components/Datepicker/DatepickerPad.jsx
@@ -47,8 +47,8 @@ const DatePickerPad = ({
 
   const labelTextKey = padIndex === 0 ? "from" : "to";
   let labelPreText;
-  if (otherValue && lang[labelTextKey]) {
-    labelPreText = <b>{lang[labelTextKey]}</b>;
+  if (otherValue && months[labelTextKey]) {
+    labelPreText = <b>{months[labelTextKey]}</b>;
   }
 
   if (month === 1 || (atMinYear && month === ymArr[0].min.month))
@@ -80,7 +80,7 @@ const DatePickerPad = ({
       </div>
       {!isMonthsMode && (
         <div>
-          <label>{month}</label>
+          <label>{months ? months[month - 1] : month}</label>
           <i
             className={classNames(
               styles.rmpBtn,
@@ -158,7 +158,7 @@ const DatePickerPad = ({
                 className={classNames(styles.rmpBtn, styles[css])}
                 data-id={`${padIndex}:${m}`}
                 onClick={clickHandler}>
-                {months.length > i ? months[i] : m}
+                {months ? months[i] : m}
               </li>
             );
           })}

--- a/src/components/Datepicker/test/datepicker.test.js
+++ b/src/components/Datepicker/test/datepicker.test.js
@@ -14,22 +14,23 @@ describe("DatePicker component", () => {
       min: { year: 2018, month: 1, day: 25 },
       max: { year: 2020, month: 2, day: 4 }
     };
+    const monthsTranslations = [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec"
+    ];
     const { queryByText, rerender, unmount } = render(
       <DatePicker
-        lang={[
-          "Jan",
-          "Feb",
-          "Mar",
-          "Apr",
-          "May",
-          "Jun",
-          "Jul",
-          "Aug",
-          "Sep",
-          "Oct",
-          "Nov",
-          "Dec"
-        ]}
+        lang={monthsTranslations}
         years={years}
         value={{ year: 2019, month: 11, day: 15 }}
         show={true}>
@@ -41,20 +42,7 @@ describe("DatePicker component", () => {
     unmount();
     rerender(
       <DatePicker
-        lang={[
-          "Jan",
-          "Feb",
-          "Mar",
-          "Apr",
-          "May",
-          "Jun",
-          "Jul",
-          "Aug",
-          "Sep",
-          "Oct",
-          "Nov",
-          "Dec"
-        ]}
+        lang={monthsTranslations}
         years={years}
         value={{ year: 2019, month: 12, day: 15 }}
         show={true}>

--- a/src/components/Datepicker/test/datepicker.test.js
+++ b/src/components/Datepicker/test/datepicker.test.js
@@ -62,7 +62,6 @@ describe("DatePicker component", () => {
       </DatePicker>
     );
     // Selected value is 15.12.2019 => Nov month is displayed.
-    console.log(queryByText(/Dec/i));
     expect(queryByText(/Dec/i)).toBeTruthy();
   });
 });

--- a/src/components/Datepicker/test/datepicker.test.js
+++ b/src/components/Datepicker/test/datepicker.test.js
@@ -10,12 +10,11 @@ describe("DatePicker component", () => {
   });
 
   test("lang prop values are used as months", () => {
-    const value = { year: 2019, month: 11, day: 15 };
     const years = {
       min: { year: 2018, month: 1, day: 25 },
       max: { year: 2020, month: 2, day: 4 }
     };
-    const { queryByText } = render(
+    const { queryByText, rerender, unmount } = render(
       <DatePicker
         lang={[
           "Jan",
@@ -32,12 +31,38 @@ describe("DatePicker component", () => {
           "Dec"
         ]}
         years={years}
-        value={value}
+        value={{ year: 2019, month: 11, day: 15 }}
         show={true}>
-        {`${value.day}/${value.month}/${value.year}`}
+        <></>
       </DatePicker>
     );
     // Selected value is 15.11.2019 => Nov month is displayed.
     expect(queryByText(/Nov/i)).toBeTruthy();
+    unmount();
+    rerender(
+      <DatePicker
+        lang={[
+          "Jan",
+          "Feb",
+          "Mar",
+          "Apr",
+          "May",
+          "Jun",
+          "Jul",
+          "Aug",
+          "Sep",
+          "Oct",
+          "Nov",
+          "Dec"
+        ]}
+        years={years}
+        value={{ year: 2019, month: 12, day: 15 }}
+        show={true}>
+        <></>
+      </DatePicker>
+    );
+    // Selected value is 15.12.2019 => Nov month is displayed.
+    console.log(queryByText(/Dec/i));
+    expect(queryByText(/Dec/i)).toBeTruthy();
   });
 });

--- a/src/components/Datepicker/test/datepicker.test.js
+++ b/src/components/Datepicker/test/datepicker.test.js
@@ -1,10 +1,43 @@
 import React from "react";
 import DatePicker from "../Datepicker";
 import { create } from "react-test-renderer";
+import { render } from "@testing-library/react";
 
 describe("DatePicker component", () => {
   test("Matches the snapshot", () => {
-    const spinner = create(<DatePicker value={{ year: 2020, month: 12 }} />);
-    expect(spinner.toJSON()).toMatchSnapshot();
+    const datePicker = create(<DatePicker value={{ year: 2020, month: 12 }} />);
+    expect(datePicker.toJSON()).toMatchSnapshot();
+  });
+
+  test("lang prop values are used as months", () => {
+    const value = { year: 2019, month: 11, day: 15 };
+    const years = {
+      min: { year: 2018, month: 1, day: 25 },
+      max: { year: 2020, month: 2, day: 4 }
+    };
+    const { queryByText } = render(
+      <DatePicker
+        lang={[
+          "Jan",
+          "Feb",
+          "Mar",
+          "Apr",
+          "May",
+          "Jun",
+          "Jul",
+          "Aug",
+          "Sep",
+          "Oct",
+          "Nov",
+          "Dec"
+        ]}
+        years={years}
+        value={value}
+        show={true}>
+        {`${value.day}/${value.month}/${value.year}`}
+      </DatePicker>
+    );
+    // Selected value is 15.11.2019 => Nov month is displayed.
+    expect(queryByText(/Nov/i)).toBeTruthy();
   });
 });

--- a/src/docs/datepicker.mdx
+++ b/src/docs/datepicker.mdx
@@ -49,6 +49,20 @@ import { DatePicker } from "../index";
       	<DatePicker
           years={years} 
           value={value}
+          lang={[
+            "Jan",
+            "Feb",
+            "Mar",
+            "Apr",
+            "May",
+            "Jun",
+            "Jul",
+            "Aug",
+            "Sep",
+            "Oct",
+            "Nov",
+            "Dec"
+          ]}
           show={isOpen}
           onChange={onChange}
         >


### PR DESCRIPTION
This diff translates months to provided `lang` array values in both months & days modes.
 