### PR TITLE
Add dark theme for warning message

### DIFF
--- a/src/theme/darkTheme.js
+++ b/src/theme/darkTheme.js
@@ -82,6 +82,9 @@ const darkTheme = {
   "error-message-background": "var(--info-message-background)",
   "error-message-color": "var(--color-astronaut-blue)",
   "blocked-message-color": "var(--error-message-color)",
+  "warning-message-background": "var(--info-message-background)",
+  "warning-message-color": "var(--color-astronaut-blue)",
+
 
   "datasheet-read-only-text-color": "var(--color-gray)",
   "datasheet-read-only-background": "var(--color-primary-darkest)",


### PR DESCRIPTION
This diff closes https://github.com/decred/politeiagui/issues/1918 issue - add dark theme for warning messages.

**UI Changes Screenshot**

After diff:
<img width="1386" alt="Screenshot 2020-05-28 at 08 40 18" src="https://user-images.githubusercontent.com/3491087/83108835-a6279b80-a0c0-11ea-8906-76f67508cd0c.png">
