### PR TITLE
[darktheme] Fix chrome's inputs autofill styling

### DIFF
--- a/src/components/TextArea/styles.css
+++ b/src/components/TextArea/styles.css
@@ -67,8 +67,8 @@
 .textArea:-webkit-autofill {
   transition-delay: 99999s;
   -webkit-transition-delay: 99999s;
-  animation-name: autofill;
-  -webkit-animation-name: autofill;
+  animation-name: "autofill";
+  -webkit-animation-name: "autofill";
   animation-fill-mode: both;
   -webkit-animation-fill-mode: both;
   -webkit-text-fill-color: var(--text-color) !important;

--- a/src/components/TextInput/styles.css
+++ b/src/components/TextInput/styles.css
@@ -84,8 +84,8 @@
 .textinput:-webkit-autofill {
   transition-delay: 99999s;
   -webkit-transition-delay: 99999s;
-  animation-name: autofill;
-  -webkit-animation-name: autofill;
+  animation-name: "autofill";
+  -webkit-animation-name: "autofill";
   animation-fill-mode: both;
   -webkit-animation-fill-mode: both;
   -webkit-text-fill-color: var(--text-color) !important;


### PR DESCRIPTION
Looks like using plain string was generating hashed value(as all class names in a css module) in the bundled css file, this now it's explicitly matching the animation name by string.
