### PR TITLE
Add prop to handle Tabs content styles

### DIFF
--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -35,6 +35,7 @@ const Tabs = ({
   children,
   wrap,
   mode,
+  contentClassName,
   ...props
 }) => {
   const dropdownMode = mode === "dropdown";
@@ -102,7 +103,10 @@ const Tabs = ({
       {transitions.map(({ item, key, props }) => {
         return (
           item === activeTabIndex && (
-            <animated.div key={key} style={props}>
+            <animated.div
+              key={key}
+              style={props}
+              className={classNames(contentClassName)}>
               {children[item] && children[item].props.children}
             </animated.div>
           )
@@ -127,7 +131,8 @@ Tabs.propTypes = {
   activeTabIndex: PropTypes.number.isRequired,
   children: PropTypes.node.isRequired,
   wrap: PropTypes.bool,
-  mode: PropTypes.oneOf(["horizontal", "vertical", "dropdown"])
+  mode: PropTypes.oneOf(["horizontal", "vertical", "dropdown"]),
+  contentClassName: PropTypes.string
 };
 
 Tabs.defaultProps = {

--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -103,10 +103,7 @@ const Tabs = ({
       {transitions.map(({ item, key, props }) => {
         return (
           item === activeTabIndex && (
-            <animated.div
-              key={key}
-              style={props}
-              className={classNames(contentClassName)}>
+            <animated.div key={key} style={props} className={contentClassName}>
               {children[item] && children[item].props.children}
             </animated.div>
           )

--- a/src/components/Tabs/tests/__snapshots__/tabs.test.js.snap
+++ b/src/components/Tabs/tests/__snapshots__/tabs.test.js.snap
@@ -55,7 +55,6 @@ Array [
     </li>
   </ul>,
   <div
-    className=""
     style={
       Object {
         "opacity": 0,

--- a/src/components/Tabs/tests/__snapshots__/tabs.test.js.snap
+++ b/src/components/Tabs/tests/__snapshots__/tabs.test.js.snap
@@ -55,6 +55,7 @@ Array [
     </li>
   </ul>,
   <div
+    className=""
     style={
       Object {
         "opacity": 0,


### PR DESCRIPTION
This diff adds the `contentClassName` prop to control Tabs content custom styles