### PR TITLE
Fix tooltip trigger on firefox mobile

### DIFF
--- a/src/components/CopyableText/tests/__snapshots__/copyableText.test.js.snap
+++ b/src/components/CopyableText/tests/__snapshots__/copyableText.test.js.snap
@@ -12,6 +12,7 @@ exports[`CopyableText component Matches snapshot 1`] = `
   </span>
   <div
     className="tooltip"
+    onClick={[Function]}
   >
     <div
       className="tooltipContent right"

--- a/src/components/StatusBar/test/__snapshots__/statusBar.test.js.snap
+++ b/src/components/StatusBar/test/__snapshots__/statusBar.test.js.snap
@@ -113,6 +113,7 @@ exports[`StatusBar component Matches the snapshot 1`] = `
     >
       <div
         className="tooltip markerTooltip"
+        onClick={[Function]}
       >
         <div
           className="tooltipContent top"

--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -1,7 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import styles from "./styles.css";
 import { classNames } from "../../utils";
+import useMediaQuery from "../../hooks/useMediaQuery";
+import useClickOutside from "../../hooks/useClickOutside";
+
+const noop = () => ({});
 
 const Tooltip = ({
   children,
@@ -11,13 +15,24 @@ const Tooltip = ({
   contentClassName,
   ...props
 }) => {
+  // Uses 1024px screen width to include big iPad sizes
+  const isMobile = useMediaQuery("(max-width: 1024px)");
+  const [isActive, toggleIsActive] = useState(false);
+  const showTooltip = () => toggleIsActive(true);
+  const hideTooltip = () => toggleIsActive(false);
+  const [tooltipRef] = useClickOutside(hideTooltip);
   return (
-    <div className={classNames(styles.tooltip, className)} {...props}>
+    <div
+      ref={tooltipRef}
+      className={classNames(styles.tooltip, className)}
+      {...props}
+      onClick={isMobile ? showTooltip : noop}>
       <div
         className={classNames(
           styles.tooltipContent,
           styles[placement],
-          contentClassName
+          contentClassName,
+          isActive && styles.showTooltip
         )}>
         {content}
       </div>

--- a/src/components/Tooltip/styles.css
+++ b/src/components/Tooltip/styles.css
@@ -55,6 +55,7 @@
   transform: translateY(-50%);
 }
 
+/* Media query to target devices with bigger screens */
 @media screen and (min-width: 1025px) {
   .tooltip:hover .tooltipContent {
     visibility: visible;

--- a/src/components/Tooltip/styles.css
+++ b/src/components/Tooltip/styles.css
@@ -13,7 +13,7 @@
   transition: 0.3s all ease;
 }
 
-.tooltip:hover .tooltipContent {
+.showTooltip {
   visibility: visible;
   opacity: 1;
 }
@@ -53,4 +53,11 @@
   left: 100%;
   top: 50%;
   transform: translateY(-50%);
+}
+
+@media screen and (min-width: 1025px) {
+  .tooltip:hover .tooltipContent {
+    visibility: visible;
+    opacity: 1;
+  }
 }

--- a/src/components/Tooltip/test/__snapshots__/tooltip.test.js.snap
+++ b/src/components/Tooltip/test/__snapshots__/tooltip.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Tooltip component Matches the snapshot 1`] = `
 <div
   className="tooltip"
+  onClick={[Function]}
 >
   <div
     className="tooltipContent top"


### PR DESCRIPTION
Fixes #259 

Using javascript to trigger tooltip on click/tap for screens smaller than 1024px. This is necessary to work on firefox mobile.