### PR TITLE
fix: change tooltip content proptype to react node

### DIFF
--- a/src/components/Tooltip/Tooltip.jsx
+++ b/src/components/Tooltip/Tooltip.jsx
@@ -43,8 +43,8 @@ const Tooltip = ({
 
 Tooltip.propTypes = {
   children: PropTypes.node,
+  content: PropTypes.node,
   placement: PropTypes.string,
-  content: PropTypes.string,
   className: PropTypes.string,
   contentClassName: PropTypes.string
 };


### PR DESCRIPTION
In some utilziations of `Tooltip` component, we need to add a custom component or smth on the `content` property. This diff modifies the propType check from string to react node.

Solves a decrediton issue: https://github.com/decred/decrediton/issues/2595