### PR TITLE
Theme: export default theme names as constants 

### DIFF
--- a/examples/web/src/App.js
+++ b/examples/web/src/App.js
@@ -10,29 +10,33 @@ import {
   defaultLightTheme,
   defaultDarkTheme,
   ThemeProvider,
-  useTheme
+  useTheme,
+  DEFAULT_LIGHT_THEME_NAME,
+  DEFAULT_DARK_THEME_NAME,
 } from "pi-ui";
 
 const ButtonWrapper = () => {
-  
   const { themeName, setThemeName } = useTheme();
-  
-  const handleToggleTheme = () => {
-    if (themeName === "light") {
-      setThemeName("dark");
-    } else {
-      setThemeName("light");
-    }
-  }
 
-  return (
-    <Button onClick={handleToggleTheme}>Toggle theme</Button>
-  )
-}
+  const handleToggleTheme = () => {
+    if (themeName === DEFAULT_LIGHT_THEME_NAME) {
+      setThemeName(DEFAULT_DARK_THEME_NAME);
+    } else {
+      setThemeName(DEFAULT_LIGHT_THEME_NAME);
+    }
+  };
+
+  return <Button onClick={handleToggleTheme}>Toggle theme</Button>;
+};
 
 const App = () => {
   return (
-    <ThemeProvider themes={{ dark: defaultDarkTheme, light: defaultLightTheme }} defaultThemeName="dark">
+    <ThemeProvider
+      themes={{
+        [DEFAULT_DARK_THEME_NAME]: defaultDarkTheme,
+        [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme,
+      }}
+      defaultThemeName={DEFAULT_DARK_THEME_NAME}>
       <Container>
         <Header>
           <div>Logo</div>

--- a/src/components/BoxTextInput/tests/boxTextInput.test.js
+++ b/src/components/BoxTextInput/tests/boxTextInput.test.js
@@ -1,15 +1,19 @@
 import React from "react";
 import BoxTextInput from "../BoxTextInput";
 import { create } from "react-test-renderer";
-import { defaultLightTheme, ThemeProvider } from "../../../theme";
+import {
+  defaultLightTheme,
+  ThemeProvider,
+  DEFAULT_LIGHT_THEME_NAME
+} from "../../../theme";
 import { fireEvent, render } from "@testing-library/react";
 
 describe("BoxTextInput component", () => {
   test("Matches the snapshot", () => {
     const boxTextInputForm = create(
       <ThemeProvider
-        themes={{ light: defaultLightTheme }}
-        defaultThemeName="light">
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
         <BoxTextInput searchInput={true} />
       </ThemeProvider>
     );
@@ -17,8 +21,8 @@ describe("BoxTextInput component", () => {
 
     const boxTextInputDefault = create(
       <ThemeProvider
-        themes={{ light: defaultLightTheme }}
-        defaultThemeName="light">
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
         <BoxTextInput />
       </ThemeProvider>
     );
@@ -30,8 +34,8 @@ describe("BoxTextInput component", () => {
 
     const { getByTestId, queryByTestId } = render(
       <ThemeProvider
-        themes={{ light: defaultLightTheme }}
-        defaultThemeName="light">
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
         <BoxTextInput onSubmit={mockedOnSubmit} searchInput={true} />
       </ThemeProvider>
     );

--- a/src/components/CopyableText/tests/copyableText.test.js
+++ b/src/components/CopyableText/tests/copyableText.test.js
@@ -1,14 +1,18 @@
 import React from "react";
 import CopyableText from "../CopyableText";
 import { create } from "react-test-renderer";
-import { defaultLightTheme, ThemeProvider } from "../../../theme";
+import {
+  defaultLightTheme,
+  ThemeProvider,
+  DEFAULT_LIGHT_THEME_NAME
+} from "../../../theme";
 
 describe("CopyableText component", () => {
   test("Matches snapshot", () => {
     const copyableText = create(
       <ThemeProvider
-        themes={{ light: defaultLightTheme }}
-        defaultThemeName="light">
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
         <CopyableText id="copy-id">test</CopyableText>
       </ThemeProvider>
     );

--- a/src/components/Datepicker/Datepicker.jsx
+++ b/src/components/Datepicker/Datepicker.jsx
@@ -38,7 +38,7 @@ const DatePicker = ({
   onYearChange,
   isMonthsMode
 }) => {
-  const { themeName } = useTheme() || { themeName: "light" };
+  const { themeName } = useTheme();
   const yearArr = useMemo(() => getYearArray(years), [years]);
   const yearIndexes = useMemo(() => [0, 0], []);
   const values = useMemo(() => validValues(value, yearArr, yearIndexes), [
@@ -352,7 +352,7 @@ const DatePicker = ({
               styles.rmpPopup,
               isMonthsMode && styles.monthsMode,
               isRange && styles.range,
-              styles[themeName],
+              themeName && styles[themeName],
               showedState && styles.show
             )}>
             {pads}

--- a/src/components/Datepicker/test/__snapshots__/datepicker.test.js.snap
+++ b/src/components/Datepicker/test/__snapshots__/datepicker.test.js.snap
@@ -39,7 +39,7 @@ exports[`DatePicker component Matches the snapshot 1`] = `
       className="rmpCell"
     >
       <div
-        className="rmpPopup light"
+        className="rmpPopup"
       />
     </div>
   </div>

--- a/src/components/Message/test/message.test.js
+++ b/src/components/Message/test/message.test.js
@@ -1,14 +1,18 @@
 import React from "react";
 import Message from "../Message";
 import { create } from "react-test-renderer";
-import { defaultLightTheme, ThemeProvider } from "../../../theme";
+import {
+  defaultLightTheme,
+  ThemeProvider,
+  DEFAULT_LIGHT_THEME_NAME
+} from "../../../theme";
 
 describe("Message component", () => {
   test("Matches the snapshot", () => {
     const message = create(
       <ThemeProvider
-        themes={{ light: defaultLightTheme }}
-        defaultThemeName="light">
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
         <Message>test</Message>
       </ThemeProvider>
     );

--- a/src/components/NumberInput/tests/numberInput.test.js
+++ b/src/components/NumberInput/tests/numberInput.test.js
@@ -1,14 +1,18 @@
 import React from "react";
 import NumberInput from "../NumberInput";
 import { create } from "react-test-renderer";
-import { defaultLightTheme, ThemeProvider } from "../../../theme";
+import {
+  defaultLightTheme,
+  ThemeProvider,
+  DEFAULT_LIGHT_THEME_NAME
+} from "../../../theme";
 
 describe("NumberInput component", () => {
   test("Matches the snapshot", () => {
     const numberInput = create(
       <ThemeProvider
-        themes={{ light: defaultLightTheme }}
-        defaultThemeName="light">
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
         <NumberInput id="test" />
       </ThemeProvider>
     );

--- a/src/components/StatusBar/StatusBar.jsx
+++ b/src/components/StatusBar/StatusBar.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styles from "./styles.css";
 import { classNames } from "../../utils";
-import { useTheme } from "../../theme";
+import { useTheme, DEFAULT_DARK_THEME_NAME } from "../../theme";
 import Tooltip from "../Tooltip/Tooltip.jsx";
 
 const StatusBar = ({
@@ -31,7 +31,7 @@ const StatusBar = ({
   });
 
   const { themeName } = useTheme();
-  const isDarkTheme = themeName === "dark";
+  const isDarkTheme = themeName === DEFAULT_DARK_THEME_NAME;
 
   const createInfoComp = (props) =>
     renderStatusInfoComponent ? (

--- a/src/components/StatusBar/test/statusBar.test.js
+++ b/src/components/StatusBar/test/statusBar.test.js
@@ -1,14 +1,18 @@
 import React from "react";
 import StatusBar from "../StatusBar";
 import { create } from "react-test-renderer";
-import { defaultLightTheme, ThemeProvider } from "../../../theme";
+import {
+  defaultLightTheme,
+  ThemeProvider,
+  DEFAULT_LIGHT_THEME_NAME
+} from "../../../theme";
 
 describe("StatusBar component", () => {
   test("Matches the snapshot", () => {
     const statusBar = create(
       <ThemeProvider
-        themes={{ light: defaultLightTheme }}
-        defaultThemeName="light">
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
         <StatusBar
           status={[
             {

--- a/src/components/Table/tests/table.test.js
+++ b/src/components/Table/tests/table.test.js
@@ -2,7 +2,11 @@ import React from "react";
 import { create } from "react-test-renderer";
 import { render, fireEvent } from "@testing-library/react";
 import Table from "../Table";
-import { defaultLightTheme, ThemeProvider } from "../../../theme";
+import {
+  defaultLightTheme,
+  ThemeProvider,
+  DEFAULT_LIGHT_THEME_NAME
+} from "../../../theme";
 
 const mockData = [
   {
@@ -21,8 +25,8 @@ describe("Table Component", () => {
   test("Matches the snapshot", () => {
     const table = create(
       <ThemeProvider
-        themes={{ light: defaultLightTheme }}
-        defaultThemeName="light">
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
         <Table data={mockData} headers={mockHeaders} />
       </ThemeProvider>
     );
@@ -32,8 +36,8 @@ describe("Table Component", () => {
   test("Table pagination", () => {
     const { getByTestId, queryByText, queryByTestId } = render(
       <ThemeProvider
-        themes={{ light: defaultLightTheme }}
-        defaultThemeName="light">
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
         <Table linesPerPage={1} data={mockData} headers={mockHeaders} />
       </ThemeProvider>
     );

--- a/src/components/Tabs/tests/tabs.test.js
+++ b/src/components/Tabs/tests/tabs.test.js
@@ -1,6 +1,10 @@
 import React from "react";
 import { create } from "react-test-renderer";
-import { defaultLightTheme, ThemeProvider } from "../../../theme";
+import {
+  defaultLightTheme,
+  ThemeProvider,
+  DEFAULT_LIGHT_THEME_NAME
+} from "../../../theme";
 import { render, fireEvent } from "@testing-library/react";
 import Tabs from "../Tabs";
 import Tab from "../Tab";
@@ -9,8 +13,8 @@ describe("Tabs Component", () => {
   test("Matches the snapshot", () => {
     const tabs = create(
       <ThemeProvider
-        themes={{ light: defaultLightTheme }}
-        defaultThemeName="light">
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
         <Tabs onSelectTab={jest.fn()} activeTabIndex={0}>
           <Tab label="tab1" count={1}>
             <div>test1</div>
@@ -31,8 +35,8 @@ describe("Tabs Component", () => {
     });
     const { getByTestId, queryByText, rerender } = render(
       <ThemeProvider
-        themes={{ light: defaultLightTheme }}
-        defaultThemeName="light">
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
         <Tabs onSelectTab={mockHandleSelectTab} activeTabIndex={activeTabIndex}>
           <Tab label="tab1" count={1}>
             <div>test1</div>
@@ -49,8 +53,8 @@ describe("Tabs Component", () => {
     expect(mockHandleSelectTab).toBeCalled();
     rerender(
       <ThemeProvider
-        themes={{ light: defaultLightTheme }}
-        defaultThemeName="light">
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
         <Tabs onSelectTab={mockHandleSelectTab} activeTabIndex={activeTabIndex}>
           <Tab label="tab1" count={1}>
             <div>test1</div>

--- a/src/components/TextArea/test/textArea.test.js
+++ b/src/components/TextArea/test/textArea.test.js
@@ -1,14 +1,18 @@
 import React from "react";
 import TextArea from "../TextArea";
 import { create } from "react-test-renderer";
-import { defaultLightTheme, ThemeProvider } from "../../../theme";
+import {
+  defaultLightTheme,
+  ThemeProvider,
+  DEFAULT_LIGHT_THEME_NAME
+} from "../../../theme";
 
 describe("TextArea component", () => {
   test("Matches the snapshot", () => {
     const textArea = create(
       <ThemeProvider
-        themes={{ light: defaultLightTheme }}
-        defaultThemeName="light">
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
         <TextArea id="test" />
       </ThemeProvider>
     );

--- a/src/components/TextInput/test/textInput.test.js
+++ b/src/components/TextInput/test/textInput.test.js
@@ -1,14 +1,18 @@
 import React from "react";
 import TextInput from "../TextInput";
 import { create } from "react-test-renderer";
-import { defaultLightTheme, ThemeProvider } from "../../../theme";
+import {
+  defaultLightTheme,
+  ThemeProvider,
+  DEFAULT_LIGHT_THEME_NAME
+} from "../../../theme";
 
 describe("TextInput component", () => {
   test("Matches the snapshot", () => {
     const textInput = create(
       <ThemeProvider
-        themes={{ light: defaultLightTheme }}
-        defaultThemeName="light">
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
         <TextInput id="test" />
       </ThemeProvider>
     );

--- a/src/components/Toggle/tests/toggle.test.js
+++ b/src/components/Toggle/tests/toggle.test.js
@@ -1,15 +1,19 @@
 import React from "react";
 import Toggle from "../Toggle";
 import { create } from "react-test-renderer";
-import { defaultLightTheme, ThemeProvider } from "../../../theme";
+import {
+  defaultLightTheme,
+  ThemeProvider,
+  DEFAULT_LIGHT_THEME_NAME
+} from "../../../theme";
 import { render, fireEvent } from "@testing-library/react";
 
 describe("Toggle Component", () => {
   test("Matches snapshot", () => {
     const toggle = create(
       <ThemeProvider
-        themes={{ light: defaultLightTheme }}
-        defaultThemeName="light">
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
         <Toggle toggled={false} />
       </ThemeProvider>
     );
@@ -20,8 +24,8 @@ describe("Toggle Component", () => {
     const mockHandleToggle = jest.fn();
     const { getByTestId } = render(
       <ThemeProvider
-        themes={{ light: defaultLightTheme }}
-        defaultThemeName="light">
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
         <Toggle toggled={false} onToggle={mockHandleToggle} />
       </ThemeProvider>
     );

--- a/src/docs/Wrapper.js
+++ b/src/docs/Wrapper.js
@@ -1,7 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { ThemeProvider, defaultLightTheme } from "../index";
+import {
+  ThemeProvider,
+  defaultLightTheme,
+  DEFAULT_LIGHT_THEME_NAME
+} from "../index";
 import SourceSansProLight from "../assets/fonts/source-sans-pro/SourceSansPro-Light.ttf";
 import SourceSansProRegular from "../assets/fonts/source-sans-pro/SourceSansPro-Regular.ttf";
 import SourceSansProSemiBold from "../assets/fonts/source-sans-pro/SourceSansPro-SemiBold.ttf";
@@ -34,16 +38,19 @@ const fonts = [
   }
 ];
 
-const DoczWrapper = ({ children }) => {
-  return (
-    <ThemeProvider
-      themes={{ light: { ...defaultLightTheme, ...themeCustomVariables } }}
-      defaultThemeName="light"
-      fonts={fonts}>
-      {children}
-    </ThemeProvider>
-  );
-};
+const DoczWrapper = ({ children }) => (
+  <ThemeProvider
+    themes={{
+      [DEFAULT_LIGHT_THEME_NAME]: {
+        ...defaultLightTheme,
+        ...themeCustomVariables
+      }
+    }}
+    defaultThemeName={DEFAULT_LIGHT_THEME_NAME}
+    fonts={fonts}>
+    {children}
+  </ThemeProvider>
+);
 
 DoczWrapper.propTypes = {
   children: PropTypes.node

--- a/src/docs/theme.mdx
+++ b/src/docs/theme.mdx
@@ -87,15 +87,16 @@ import React from "react";
 import { useTheme, Button, getThemeProperty } from "pi-ui";
 
 const DeepChild = () => {
-  const { themeName, setThemeName, theme } = useTheme();
+  const { themeName, setThemeName, theme, DEFAULT_LIGHT_THEME_NAME,
+    DEFAULT_DARK_THEME_NAME } = useTheme();
 
   const colorGreen = getThemeProperty(theme, "color-green"); // get theme property 
   
   const handleToggleTheme = () => {
-    if (themeName === "light") {
-      setThemeName("dark");
+    if (themeName === DEFAULT_LIGHT_THEME_NAME) {
+      setThemeName(DEFAULT_LIGHT_THEME_NAME);
     } else {
-      setThemeName("light");
+      setThemeName(DEFAULT_LIGHT_THEME_NAME);
     }
   }
 

--- a/src/docs/theme.mdx
+++ b/src/docs/theme.mdx
@@ -25,7 +25,7 @@ Pi-ui exposes a `ThemeProvider` that accepts a `themes` object, `defaultThemeNam
 ```js
 import React from "react";
 import { render } from "react-dom";
-import { ThemeProvider, defaultLightTheme } from "pi-ui";
+import { ThemeProvider, defaultLightTheme, DEFAULT_LIGHT_THEME_NAME } from "pi-ui";
 
 import customTheme from "./theme";
 import SourceSansProLight from "../assets/fonts/source-sans-pro/SourceSansPro-Light.ttf";
@@ -59,7 +59,7 @@ const fonts = [
 const App = () => {
   return (
     <ThemeProvider
-      themes={{ light: defaultLightTheme, customTheme }}
+      themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme, customTheme }}
       defaultThemeName="customTheme"
       fonts={fonts}>
       {children}
@@ -72,10 +72,13 @@ render(<App />, document.getElementById("root"));
 
 ## Default theme
 
-There are two default themes, `defaultLightTheme` and `defaultDarkTheme`. They are both name exported from pi-ui.
+There are two default themes, `defaultLightTheme` and `defaultDarkTheme`. They are both exported from pi-ui.
+
+It's recommended to use `DEFAULT_LIGHT_THEME_NAME` and `DEFAULT_DARK_THEME_NAME` default theme names, as they are used
+internally in some components to use dark default styling variables or the light ones.
 
 ```js
-import { defaultLightTheme, defaultDarkTheme } from "pi-ui";
+import { defaultLightTheme, defaultDarkTheme, DEFAULT_LIGHT_THEME_NAME, DEFAULT_DARK_THEME_NAME } from "pi-ui";
 ```
 
 ## UseTheme hook in deep children
@@ -84,11 +87,10 @@ import { defaultLightTheme, defaultDarkTheme } from "pi-ui";
 
 ```js
 import React from "react";
-import { useTheme, Button, getThemeProperty } from "pi-ui";
+import { useTheme, Button, getThemeProperty, DEFAULT_LIGHT_THEME_NAME, DEFAULT_DARK_THEME_NAME } from "pi-ui";
 
 const DeepChild = () => {
-  const { themeName, setThemeName, theme, DEFAULT_LIGHT_THEME_NAME,
-    DEFAULT_DARK_THEME_NAME } = useTheme();
+  const { themeName, setThemeName, theme } = useTheme();
 
   const colorGreen = getThemeProperty(theme, "color-green"); // get theme property 
   

--- a/src/theme/ThemeProvider.js
+++ b/src/theme/ThemeProvider.js
@@ -9,7 +9,7 @@ import PropTypes from "prop-types";
 
 const ThemeContext = createContext();
 
-export const useTheme = () => useContext(ThemeContext);
+export const useTheme = () => useContext(ThemeContext) || {};
 
 export const ThemeProvider = ({
   themes,

--- a/src/theme/constants.js
+++ b/src/theme/constants.js
@@ -1,0 +1,6 @@
+/*
+ * The following constants are used throughout the application to determine
+ * if the current active theme is default light or dark theme
+ */
+export const DEFAULT_LIGHT_THEME_NAME = "light";
+export const DEFAULT_DARK_THEME_NAME = "dark";

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -2,3 +2,4 @@ export { default as defaultDarkTheme } from "./darkTheme";
 export { default as defaultLightTheme } from "./lightTheme";
 export * from "./ThemeProvider";
 export * from "./helpers";
+export * from "./constants";


### PR DESCRIPTION
While working on https://github.com/decred/decrediton/issues/2829 I noticed that decrediton is using different theme names as the default ones used in `pi-ui` & `pigui`, this is a bit problematic and may cause some styling bugs, as we check internally in `pi-ui` if default dark theme is used by checking the current theme name: `const isDarkTheme = themeName === "dark"`, and using different theme names as we do in decrediton would cause some pi-ui's components to show wrong styling.

So as solution this diff exports two constants for default themes names: `DEFAULT_LIGHT_THEME_NAME` & `DEFAULT_DARK_THEME_NAME`, and uses them when it determines if default dark styling should be used internally in pi-ui's components.  After this commit consumers of pi-ui lib would need to provide these default themes names if they are interested in default components' dark/light styling. 

Needed for: https://github.com/decred/decrediton/pull/2841 & https://github.com/decred/politeiagui/pull/2177