### PR TITLE
Tabs component improvements

### DIFF
--- a/src/components/Tabs/Tab.jsx
+++ b/src/components/Tabs/Tab.jsx
@@ -23,11 +23,14 @@ const Tab = ({
   };
   const activeBorderColor = getThemeProperty(theme, "tab-active-color");
   const defaultBorderColor = getThemeProperty(theme, "topbanner-color");
+  const activeBackgroundColor = getThemeProperty(theme, "tab-active-background");
+  const defaultBackgroundColor = getThemeProperty(theme, "tab-default-background");
   const activeTextColor = getThemeProperty(theme, "tab-text-active-color");
   const defaultTextColor = getThemeProperty(theme, "tab-text-color");
   const slide = useSpring({
     borderColor: isActive ? activeBorderColor : defaultBorderColor,
     color: isActive ? activeTextColor : defaultTextColor,
+    backgroundColor: isActive ? activeBackgroundColor : defaultBackgroundColor,
     duration: 350
   });
 

--- a/src/components/Tabs/Tab.jsx
+++ b/src/components/Tabs/Tab.jsx
@@ -22,7 +22,7 @@ const Tab = ({
     onSelect(tabIndex);
   };
   const activeBorderColor = getThemeProperty(theme, "tab-active-color");
-  const defaultBorderColor = getThemeProperty(theme, "topbanner-color");
+  const defaultBorderColor = getThemeProperty(theme, "tab-default-color");
   const activeBackgroundColor = getThemeProperty(theme, "tab-active-background");
   const defaultBackgroundColor = getThemeProperty(theme, "tab-default-background");
   const activeTextColor = getThemeProperty(theme, "tab-text-active-color");

--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -60,7 +60,7 @@ const Tabs = ({
           element
         );
       });
-  }, [children, activeTabIndex, mode, vertical, onSelectTab]);
+  }, [children, activeTabIndex, mode, onSelectTab, dropdownMode]);
 
   const tabs = useMemo(
     () => (

--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -52,7 +52,7 @@ const Tabs = ({
           isActive: index === activeTabIndex,
           mode
         });
-        return vertical ? (
+        return dropdownMode ? (
           <DropdownItem className={styles.customDropdownItem}>
             {element}
           </DropdownItem>

--- a/src/components/Tabs/tests/__snapshots__/tabs.test.js.snap
+++ b/src/components/Tabs/tests/__snapshots__/tabs.test.js.snap
@@ -11,6 +11,7 @@ Array [
       onClick={[Function]}
       style={
         Object {
+          "backgroundColor": "transparent",
           "borderColor": "rgba(46, 216, 163, 1)",
           "color": "rgba(9, 20, 64, 1)",
           "duration": 350,
@@ -35,6 +36,7 @@ Array [
       onClick={[Function]}
       style={
         Object {
+          "backgroundColor": "transparent",
           "borderColor": "rgba(255, 255, 255, 1)",
           "color": "rgba(61, 88, 115, 1)",
           "duration": 350,

--- a/src/theme/lightTheme.js
+++ b/src/theme/lightTheme.js
@@ -128,6 +128,8 @@ const lightTheme = {
   /** Tabs */
   "tab-active-underline-color": "var(--color-yellow)",
   "tab-active-font-color": "var(--color-primary-dark)",
+  "tab-active-background": "none",
+  "tab-default-background": "none",
   "tab-count-background": "var(--color-gray-lighter)",
   "tab-active-color": "var(--color-primary-light)",
   "tab-text-color": "var(--color-gray-dark)",

--- a/src/theme/lightTheme.js
+++ b/src/theme/lightTheme.js
@@ -128,10 +128,11 @@ const lightTheme = {
   /** Tabs */
   "tab-active-underline-color": "var(--color-yellow)",
   "tab-active-font-color": "var(--color-primary-dark)",
-  "tab-active-background": "none",
-  "tab-default-background": "none",
+  "tab-active-background": "transparent",
+  "tab-default-background": "transparent",
   "tab-count-background": "var(--color-gray-lighter)",
   "tab-active-color": "var(--color-primary-light)",
+  "tab-default-color": "var(--topbanner-color)",
   "tab-text-color": "var(--color-gray-dark)",
   "tab-text-active-color": "var(--color-primary-dark)",
 


### PR DESCRIPTION
While I was utilizing the `Tabs` component for the decrediton sidebar ([decred/decrediton#3077](https://github.com/decred/decrediton/pull/3077)), I noticed that the `Tabs` wraps the li element unnecessary into a `DropdownItem` when it is in vertical mode. This diff fixes this.
I also added the possibility to change the background color and default border color of `Tab` by changing the related theme variable.