### PR TITLE
Solving missing ID when truncate is false

### DIFF
--- a/src/components/CopyableText/CopyableText.jsx
+++ b/src/components/CopyableText/CopyableText.jsx
@@ -26,7 +26,7 @@ const CopyableText = ({
   };
   return (
     <div className={classNames(styles.copyableWrapper, className)} {...props}>
-      <Text id={id} truncate className={styles.contentWrapper}>
+      <Text id={id} truncate={truncate} className={styles.contentWrapper}>
         {children}
       </Text>
       <Tooltip

--- a/src/components/CopyableText/CopyableText.jsx
+++ b/src/components/CopyableText/CopyableText.jsx
@@ -54,7 +54,7 @@ CopyableText.propTypes = {
 };
 
 CopyableText.defaultProps = {
-  truncate: false,
+  truncate: true,
   hoverText: "Copy to clipboard",
   tooltipPlacement: "right"
 };


### PR DESCRIPTION
Fixes #298 

Using `truncate` param instead of hard coded `truncate`