### PR TITLE
Fixing size of sidebar on huge screens.

### DIFF
--- a/src/components/Layout/styles.css
+++ b/src/components/Layout/styles.css
@@ -50,7 +50,7 @@
 }
 
 /* HUGE SCREENS */
-@media screen and (min-width: 1400px) {
+@media screen and (min-width: 1560px) {
   .container {
     grid-template-columns:
       [full-start] 1fr [center-start]


### PR DESCRIPTION
The old layout system creates a 10-2 proportion on the screen for the sidebar when the width is greater than 1400px. That generates a result like this, on 14'' screens:

![image](https://user-images.githubusercontent.com/54870899/105634261-f0257480-5e3b-11eb-9e6e-ff704361f32e.png)

To fix this problem, it was changed the minimum width to be 1560px, that way, the minimum sidebar width would be 130px, since the screen is divided on a 10-2 proportion.
> 1560px Screen:

![Screenshot from 2021-01-22 16-28-30](https://user-images.githubusercontent.com/54870899/105634368-6fb34380-5e3c-11eb-9d4c-540869d4f060.png)

> < 1560px Screen:

![Screenshot from 2021-01-22 16-28-38](https://user-images.githubusercontent.com/54870899/105634394-88bbf480-5e3c-11eb-9b0f-dbb1a217a414.png)

Closes #296.
