### PR TITLE
Fix tabs animation

### DIFF
--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -89,10 +89,12 @@ const Tabs = ({
   };
 
   const transition = useTransition(activeTabIndex, {
-    from: { opacity: 0 },
+    initial: { position: "absolute", opacity: 1 },
+    from: { position: "absolute", opacity: 0 },
     enter: { opacity: 1 },
     leave: { opacity: 0 },
-    config: { duration: 350 }
+    config: { duration: 350 },
+    keys: (item) => item
   });
 
   return (
@@ -108,9 +110,9 @@ const Tabs = ({
       ) : (
         tabs
       )}
-      {transition(({ opacity }) => (
-        <animated.div style={{ opacity }} className={contentClassName}>
-          {children[activeTabIndex] && children[activeTabIndex].props.children}
+      {transition((style, item) => (
+        <animated.div style={style} className={contentClassName}>
+          {children[item] && children[item].props.children}
         </animated.div>
       ))}
     </>

--- a/src/components/Tabs/tests/__snapshots__/tabs.test.js.snap
+++ b/src/components/Tabs/tests/__snapshots__/tabs.test.js.snap
@@ -59,7 +59,8 @@ Array [
   <div
     style={
       Object {
-        "opacity": 0,
+        "opacity": 1,
+        "position": "absolute",
       }
     }
   >


### PR DESCRIPTION
The animation is flickering when switching between the contents of Tabs. This has an effect on decrediton too: https://github.com/decred/decrediton/issues/3201
In this diff, I have fixed the animation and updated the related test to handle the async aspect of the animation. 
I used this diff in decrediton: https://github.com/decred/decrediton/pull/3209
 
![Screen Recording 2021-02-09 at 16 53 33](https://user-images.githubusercontent.com/52497040/107390252-ccc71e80-6af7-11eb-9880-94c78a8a02b7.gif)
