### PR TITLE
TextInput component improvements

### DIFF
--- a/src/components/NumberInput/tests/__snapshots__/numberInput.test.js.snap
+++ b/src/components/NumberInput/tests/__snapshots__/numberInput.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`NumberInput component Matches the snapshot 1`] = `
 <div
-  className="textinputWrapper numberInputWrapper"
+  className="textinputWrapper numberInputWrapper withoutLabel"
 >
   <input
     className="textinput numberInput"
@@ -10,32 +10,10 @@ exports[`NumberInput component Matches the snapshot 1`] = `
     placeholder=" "
     type="number"
   />
-  <label
-    className="textinputLabel"
-    htmlFor="test"
-  >
-    
-  </label>
-  <svg
-    className="errorIcon"
-    height="16"
-    viewBox="0 0 450 450"
-    width="16"
-  >
-    <path
-      d="M225.24,24.86c-110.46,0-200,89.55-200,200s89.54,200,200,200,200-89.55,200-200S335.69,24.86,225.24,24.86Z"
-      fill="#ed6d47"
-    />
-    <rect
-      fill="none"
-    />
-    <path
-      d="M188.2,313c0-21.92,15.7-36.84,36.8-36.84s36.8,14.92,36.8,36.84-15.7,37.47-36.8,37.47S188.2,335,188.2,313Zm11.56-164.61L198,99.49H252l-1.8,48.94-7.5,103.67H207.26Z"
-      fill="#feb8a5"
-    />
-  </svg>
+  
+  <div />
   <p
-    className="errorMsg"
+    className="message"
   />
 </div>
 `;

--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -3,61 +3,93 @@ import React from "react";
 import { classNames } from "../../utils";
 import Icon from "../Icon/Icon.jsx";
 import styles from "./styles.css";
+import { useMountEffect } from "../../hooks";
 
 const TextInput = ({
+  children,
   type,
   label,
+  placeholder,
   id,
   error,
+  success,
+  autoFocus,
   wrapperClassNames,
   inputClassNames,
   ...props
 }) => {
+  const input = React.useRef(null);
+  useMountEffect(() => autoFocus && input && input.current.focus());
+
   return (
-    <div className={classNames(styles.textinputWrapper, wrapperClassNames)}>
+    <div
+      className={classNames(
+        styles.textinputWrapper,
+        error && styles.error,
+        success && styles.success,
+        wrapperClassNames,
+        !label && styles.withoutLabel
+      )}>
       <input
         id={id}
-        placeholder=" "
-        className={classNames(
-          styles.textinput,
-          error && styles.textinputError,
-          inputClassNames
-        )}
+        ref={input}
+        placeholder={placeholder || " "}
+        className={classNames(styles.textinput, inputClassNames)}
         type={type}
         {...props}
       />
-      <label htmlFor={id} className={styles.textinputLabel}>
-        {label}
-      </label>
-      <Icon
-        type="alert"
-        backgroundColor="#ed6d47"
-        iconColor="#feb8a5"
-        className={classNames(
-          styles.errorIcon,
-          error && styles.errorIconActive
+      {label && (
+        <label
+          htmlFor={id}
+          className={classNames(
+            styles.textinputLabel,
+            placeholder && styles.staticTextInputLabel
+          )}>
+          {label}
+        </label>
+      )}
+      <div>
+        {children && <div className={styles.childrenWrapper}>{children}</div>}
+        {error && (
+          <Icon
+            type="alert"
+            backgroundColor="#ed6d47"
+            iconColor="#feb8a5"
+            className={styles.errorIcon}
+          />
         )}
-      />
-      <p
-        className={classNames(styles.errorMsg, error && styles.errorMsgActive)}>
+        {success && (
+          <Icon
+            type="checkmark"
+            backgroundColor="#41bf53"
+            iconColor="#c6eccb"
+            className={styles.successIcon}
+          />
+        )}
+      </div>
+      <p className={styles.message}>
         {error}
+        {success}
       </p>
     </div>
   );
 };
 
 TextInput.propTypes = {
+  children: PropTypes.node,
   type: PropTypes.string,
   label: PropTypes.string,
+  placeholder: PropTypes.string,
   id: PropTypes.string.isRequired,
   error: PropTypes.string,
+  success: PropTypes.string,
+  autoFocus: PropTypes.bool,
   wrapperClassNames: PropTypes.string,
   inputClassNames: PropTypes.string
 };
 
 TextInput.defaultProps = {
-  type: "text",
-  label: "Label"
+  type: "text"
 };
 
 export default TextInput;

--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -16,6 +16,7 @@ const TextInput = ({
   autoFocus,
   wrapperClassNames,
   inputClassNames,
+  labelClassNames,
   ...props
 }) => {
   const input = React.useRef(null);
@@ -43,7 +44,8 @@ const TextInput = ({
           htmlFor={id}
           className={classNames(
             styles.textinputLabel,
-            placeholder && styles.staticTextInputLabel
+            placeholder && styles.staticTextInputLabel,
+            labelClassNames
           )}>
           {label}
         </label>
@@ -85,7 +87,8 @@ TextInput.propTypes = {
   success: PropTypes.string,
   autoFocus: PropTypes.bool,
   wrapperClassNames: PropTypes.string,
-  inputClassNames: PropTypes.string
+  inputClassNames: PropTypes.string,
+  labelClassNames: PropTypes.string
 };
 
 TextInput.defaultProps = {

--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -17,6 +17,7 @@ const TextInput = ({
   wrapperClassNames,
   inputClassNames,
   labelClassNames,
+  messageClassNames,
   ...props
 }) => {
   const input = React.useRef(null);
@@ -69,7 +70,7 @@ const TextInput = ({
           />
         )}
       </div>
-      <p className={styles.message}>
+      <p className={classNames(styles.message, messageClassNames)}>
         {error}
         {success}
       </p>
@@ -88,7 +89,8 @@ TextInput.propTypes = {
   autoFocus: PropTypes.bool,
   wrapperClassNames: PropTypes.string,
   inputClassNames: PropTypes.string,
-  labelClassNames: PropTypes.string
+  labelClassNames: PropTypes.string,
+  messageClassNames: PropTypes.string
 };
 
 TextInput.defaultProps = {

--- a/src/components/TextInput/styles.css
+++ b/src/components/TextInput/styles.css
@@ -1,3 +1,18 @@
+.textinputWrapper {
+  width: 100%;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.textinputWrapper:not(:first-child) {
+  margin-top: 2.2rem;
+}
+
+.textinputWrapper.withoutLabel {
+  margin-top: 0;
+}
+
 .textinput {
   background-color: transparent;
   outline: 0;
@@ -8,15 +23,6 @@
   transition: all 0.25s;
   line-height: var(--spacing-2);
   color: var(--text-color);
-}
-
-.textinputWrapper {
-  width: 100%;
-  position: relative;
-}
-
-.textinputWrapper:not(:first-child) {
-  margin-top: 2.2rem;
 }
 
 .textinputLabel {
@@ -34,42 +40,73 @@
   border-bottom: 0.1rem solid var(--color-primary);
 }
 
-.textinputError,
-.textinputError:focus,
-.textinputError:not(:placeholder-shown) {
-  border-bottom: 0.1rem solid var(--color-orange);
-}
-
 .textinput:focus + .textinputLabel,
 .textinput:not(:placeholder-shown) + .textinputLabel {
   top: -2rem;
   font-size: var(--font-size-small);
 }
 
-.errorMsg {
+.staticTextInputLabel:focus + .textinputLabel,
+.staticTextInputLabel {
+  position: relative;
+  top: initial !important;
+  order: -1;
+  font-size: var(--font-size-small);
+}
+
+.message {
+  position: relative;
   visibility: hidden;
-  color: var(--color-orange);
   font-size: var(--font-size-small);
   min-height: var(--spacing-1);
   line-height: var(--spacing-1);
   margin-top: 1px;
 }
 
-.errorMsgActive {
+.textinputWrapper.error .message {
   visibility: visible;
+  color: var(--color-orange);
+  text-align: left;
+}
+
+.textinputWrapper.success .message {
+  visibility: visible;
+  color: var(--color-green);
+  text-align: left;
 }
 
 .errorIcon {
-  display: none;
   color: var(--color-orange);
   position: absolute;
   right: 0;
-  top: 2px;
+  transform: translateY(-100%) translateY(-5px);
   font-size: var(--font-size-large);
 }
 
-.errorIconActive {
-  display: block;
+.successIcon {
+  position: absolute;
+  right: 0;
+  transform: translateY(-100%) translateY(-5px);
+  font-size: var(--font-size-large);
+}
+
+.childrenWrapper {
+  position: absolute;
+  right: 0;
+  transform: translateY(-100%) translateY(-5px);
+}
+
+.childrenWrapper,
+.childrenWrapper > div {
+  line-height: 0;
+}
+
+.childrenWrapper > div > * {
+  line-height: initial;
+}
+
+.textinputWrapper.error .childrenWrapper {
+  right: 20px;
 }
 
 /* override chrome's autocomplete styling */
@@ -89,4 +126,22 @@
   animation-fill-mode: both;
   -webkit-animation-fill-mode: both;
   -webkit-text-fill-color: var(--text-color) !important;
+}
+
+.textinputWrapper.success .textinput {
+  border-bottom: 0.1rem solid var(--color-green);
+}
+
+.textinputWrapper.error .textinput {
+  border-bottom: 0.1rem solid var(--color-orange);
+}
+
+.textinputWrapper.success .textinput:focus,
+.textinputWrapper.success .textinput:not(:placeholder-shown) {
+  border-bottom: 0.1rem solid var(--color-green);
+}
+
+.textinputWrapper.error .textinput:focus,
+.textinputWrapper.error .textinput:not(:placeholder-shown) {
+  border-bottom: 0.1rem solid var(--color-orange);
 }

--- a/src/components/TextInput/test/__snapshots__/textInput.test.js.snap
+++ b/src/components/TextInput/test/__snapshots__/textInput.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`TextInput component Matches the snapshot 1`] = `
 <div
-  className="textinputWrapper"
+  className="textinputWrapper withoutLabel"
 >
   <input
     className="textinput"
@@ -10,32 +10,9 @@ exports[`TextInput component Matches the snapshot 1`] = `
     placeholder=" "
     type="text"
   />
-  <label
-    className="textinputLabel"
-    htmlFor="test"
-  >
-    Label
-  </label>
-  <svg
-    className="errorIcon"
-    height="16"
-    viewBox="0 0 450 450"
-    width="16"
-  >
-    <path
-      d="M225.24,24.86c-110.46,0-200,89.55-200,200s89.54,200,200,200,200-89.55,200-200S335.69,24.86,225.24,24.86Z"
-      fill="#ed6d47"
-    />
-    <rect
-      fill="none"
-    />
-    <path
-      d="M188.2,313c0-21.92,15.7-36.84,36.8-36.84s36.8,14.92,36.8,36.84-15.7,37.47-36.8,37.47S188.2,335,188.2,313Zm11.56-164.61L198,99.49H252l-1.8,48.94-7.5,103.67H207.26Z"
-      fill="#feb8a5"
-    />
-  </svg>
+  <div />
   <p
-    className="errorMsg"
+    className="message"
   />
 </div>
 `;

--- a/src/docs/textInput.mdx
+++ b/src/docs/textInput.mdx
@@ -5,7 +5,7 @@ route: /components/textinput
 ---
 
 import { Playground, Props } from "docz";
-import { TextInput } from "../index";
+import { TextInput, Icon, Tooltip } from "../index";
 
 # TextInput
 
@@ -27,4 +27,28 @@ import { TextInput } from "../index";
 <Playground>
   <TextInput id="email2" label="Email" name="email" error="Incorrect email" />
   <TextInput id="password2" label="Password" type="password" name="password" error="Incorrect password" />
+</Playground>
+
+### Success
+
+<Playground>
+  <TextInput id="email3" label="Email" name="email" success="Correct email" />
+  <TextInput id="password3" label="Password" type="password" name="password" success="Correct password" />
+</Playground>
+
+### Placeholder
+
+<Playground>
+  <TextInput id="email4" label="Email" name="email" placeholder="Write your email" />
+  <TextInput id="password4" label="Password" type="password" name="password" placeholder="Write your password"/>
+</Playground>
+
+### Child component
+
+<Playground>
+  <TextInput id="destination" label="Destination" name="destination" placeholder="Choose destination..." >
+    <Tooltip content="Select a path">
+      <Icon type="search" />
+    </Tooltip>
+  </TextInput>
 </Playground>

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -3,3 +3,4 @@ export { default as useMediaQuery } from "./useMediaQuery";
 export { default as useHover } from "./useHover";
 export { default as useClickOutside } from "./useClickOutside";
 export { default as useLockBodyScrollOnTrue } from "./useLockBodyScrollOnTrue";
+export { default as useMountEffect } from "./useMountEffect";

--- a/src/hooks/useMountEffect.js
+++ b/src/hooks/useMountEffect.js
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+
+/**
+ * This is copied from Decrediton
+ *
+ * useMountEffect is a custom hook to run an effect on mount
+ * only once, it accepts an effect/function and executes it
+ * only after succesful mount (empty array as second argument
+ * in useEffect call)
+ *
+ * Note: eslint react-hooks/exhaustive-deps is disabled here due to this being
+ * specifically to run a function on the very first mount, independently of fun
+ * changing, thus `fun` is not supposed to actually be a dependency.
+ *
+ * @param {*} fun - effect to run on mount
+ */
+const useMountEffect = (fun) => useEffect(fun, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+export default useMountEffect;


### PR DESCRIPTION
I am working on a decrediton PR that uses the `TextInput` component (https://github.com/decred/decrediton/pull/3398)
Some features are missing. This diff implements them:
- inputs in decrediton show placeholder and label at the same time and not an animated label/placeholder one. Now if the `placeholder` prop is defined, the label stays in its static position. In this condition, the label is positioned relative (and not absolute with negative top attribute) to the easier component positioning.
  <img width="333" alt="DeepinScreenshot_select-area_20210419154431" src="https://user-images.githubusercontent.com/52497040/115247629-40546000-a127-11eb-92a2-84d468c4f40b.png">
- the top style label positioning has introduced just in the latest designs. Because of this, the label can be left from props now and can be handled outside of the component.
  <img width="326" alt="DeepinScreenshot_select-area_20210419160118" src="https://user-images.githubusercontent.com/52497040/115249034-84943000-a128-11eb-9628-e098c73c7222.png">
- add `autoFocus` property
- add support to add child component(s), like a `Paste` button or a `Search` icon to the inputs right side.
  <img width="346" alt="DeepinScreenshot_select-area_20210419154448" src="https://user-images.githubusercontent.com/52497040/115247525-23b82800-a127-11eb-81ae-49197aa6a4aa.png">
  Positioning respects `error` and `success` icons:
  <img width="288" alt="DeepinScreenshot_select-area_20210419155854" src="https://user-images.githubusercontent.com/52497040/115248630-26674d00-a128-11eb-93c0-3c1b99cdb3f2.png">
- add success state 
  <img width="299" alt="DeepinScreenshot_select-area_20210419154619" src="https://user-images.githubusercontent.com/52497040/115247322-f9ff0100-a126-11eb-9599-908287bfb774.png">

