### PR TITLE
Fix TextInput component

### DIFF
--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -21,7 +21,9 @@ const TextInput = ({
   ...props
 }) => {
   const input = React.useRef(null);
-  useMountEffect(() => autoFocus && input && input.current.focus());
+  useMountEffect(() => {
+    autoFocus && input && input.current.focus();
+  });
 
   return (
     <div


### PR DESCRIPTION
This diff fixes a bug that was introduced in #326
The `useMountEffect` custom hook receives a callback function as a parameter and this function must not return anything.
It caused an error: https://github.com/decred/decrediton/pull/3398#pullrequestreview-675546089