### PR TITLE
add new color for the links on dark theme

### DIFF
--- a/src/components/Link/styles.css
+++ b/src/components/Link/styles.css
@@ -1,5 +1,5 @@
 .link {
-  color: var(--color-primary);
+  color: var(--link-color);
   font-weight: var(--font-weight-regular);
 }
 

--- a/src/theme/darkTheme.js
+++ b/src/theme/darkTheme.js
@@ -3,7 +3,7 @@ import lightTheme from "./lightTheme";
 const darkTheme = {
   ...lightTheme,
 
-  "color-primary-dark": "#7DA7D9",
+  "link-color": "#56A4FF",
   "color-primary-darker": "#1F325F",
   "color-primary-darkest": "#1B2B54",
   "color-primary-dark-link": "#56A4FF",

--- a/src/theme/darkTheme.js
+++ b/src/theme/darkTheme.js
@@ -6,6 +6,7 @@ const darkTheme = {
   "color-primary-dark": "#7DA7D9",
   "color-primary-darker": "#1F325F",
   "color-primary-darkest": "#1B2B54",
+  "color-primary-dark-link": "#56A4FF",
   "color-dark": "#091440",
   "color-gray-blue": "#6F98D3",
 

--- a/src/theme/darkTheme.js
+++ b/src/theme/darkTheme.js
@@ -6,7 +6,6 @@ const darkTheme = {
   "link-color": "#56A4FF",
   "color-primary-darker": "#1F325F",
   "color-primary-darkest": "#1B2B54",
-  "color-primary-dark-link": "#56A4FF",
   "color-dark": "#091440",
   "color-gray-blue": "#6F98D3",
 

--- a/src/theme/lightTheme.js
+++ b/src/theme/lightTheme.js
@@ -23,6 +23,8 @@ const lightTheme = {
   "color-gray-lightest2": "#f9fafa",
   "color-white": "#ffffff",
 
+  "link-color": "var(--color-primary)",
+
   "html-bg": "var(--color-gray-lightest)",
 
   "color-shadow-light": "rgba(0, 0, 0, 0.2)",


### PR DESCRIPTION
### Add a new color to the palette for the links on the dark theme.

The old  primary-color is hard to see on dark theme. After discussion we decide to add  a new color to the palette 

See the detail of the dicussion here [politeiagui/pull/2407](https://github.com/decred/politeiagui/pull/2407#issuecomment-867172638)