### PR TITLE
Datepicker: various improvements in date range mode.

### DIFF
--- a/src/components/Datepicker/DatepickerPad.jsx
+++ b/src/components/Datepicker/DatepickerPad.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import styles from "./styles.css";
 import { classNames } from "../../utils";
-import { mapToArray } from "./helpers";
+import { mapToArray, convertObjectToUnixTimestamp } from "./helpers";
 
 const DatePickerPad = ({
   padIndex,
@@ -170,6 +170,44 @@ const DatePickerPad = ({
               d === value.day
             ) {
               css = "active";
+            }
+            if (
+              values.length > 1 &&
+              padIndex === 0 &&
+              value &&
+              otherValue &&
+              ((year === value.year &&
+                month === value.month &&
+                d > value.day) ||
+                (((year === value.year && month > value.month) ||
+                  year > value.year) &&
+                  convertObjectToUnixTimestamp({ day: d, month, year }) <=
+                    convertObjectToUnixTimestamp({
+                      day: otherValue.day,
+                      month: otherValue.month,
+                      year: otherValue.year
+                    })))
+            ) {
+              css = "select";
+            }
+            if (
+              values.length > 1 &&
+              padIndex === 1 &&
+              value &&
+              otherValue &&
+              ((year === value.year &&
+                month === value.month &&
+                d < value.day) ||
+                (((year === value.year && month < value.month) ||
+                  year < value.year) &&
+                  convertObjectToUnixTimestamp({ day: d, month, year }) >=
+                    convertObjectToUnixTimestamp({
+                      day: otherValue.day,
+                      month: otherValue.month,
+                      year: otherValue.year
+                    })))
+            ) {
+              css = "select";
             }
             if (
               atMinYear &&

--- a/src/components/Datepicker/DatepickerPad.jsx
+++ b/src/components/Datepicker/DatepickerPad.jsx
@@ -171,6 +171,8 @@ const DatePickerPad = ({
             ) {
               css = "active";
             }
+            // In range mode if both values selected highlight the range
+            // items in the first pad (left side).
             if (
               values.length > 1 &&
               padIndex === 0 &&
@@ -190,6 +192,8 @@ const DatePickerPad = ({
             ) {
               css = "select";
             }
+            // In range mode if both values selected highlight the range
+            // items in the second pad (right side).
             if (
               values.length > 1 &&
               padIndex === 1 &&
@@ -222,6 +226,32 @@ const DatePickerPad = ({
               d > ymArr[yearMaxIdx].max.day
             ) {
               css = "disable";
+            }
+            // In range mode if other value is selected disable items
+            // which exceed it.
+            if (otherValue) {
+              const currentTimestamp = convertObjectToUnixTimestamp({
+                day: d,
+                month,
+                year
+              });
+              const otherValueTimestamp = convertObjectToUnixTimestamp({
+                day: otherValue.day,
+                month: otherValue.month,
+                year: otherValue.year
+              });
+              switch (padIndex) {
+                case 0:
+                  if (currentTimestamp > otherValueTimestamp) {
+                    css = "disable";
+                  }
+                  break;
+                case 1:
+                  if (currentTimestamp < otherValueTimestamp) {
+                    css = "disable";
+                  }
+                  break;
+              }
             }
             const clickHandler = css !== "disable" ? onDayClick : undefined;
             return (

--- a/src/components/Datepicker/DatepickerPad.jsx
+++ b/src/components/Datepicker/DatepickerPad.jsx
@@ -4,6 +4,8 @@ import styles from "./styles.css";
 import { classNames } from "../../utils";
 import { mapToArray, convertObjectToUnixTimestamp } from "./helpers";
 
+const isValidDate = (date) => date && date.day && date.month && date.year
+
 const DatePickerPad = ({
   padIndex,
   values,
@@ -176,8 +178,8 @@ const DatePickerPad = ({
             if (
               values.length > 1 &&
               padIndex === 0 &&
-              value &&
-              otherValue &&
+              isValidDate(value) &&
+              isValidDate(otherValue) &&
               ((year === value.year &&
                 month === value.month &&
                 d > value.day) ||
@@ -197,8 +199,8 @@ const DatePickerPad = ({
             if (
               values.length > 1 &&
               padIndex === 1 &&
-              value &&
-              otherValue &&
+              isValidDate(value) &&
+              isValidDate(otherValue) &&
               ((year === value.year &&
                 month === value.month &&
                 d < value.day) ||
@@ -229,7 +231,7 @@ const DatePickerPad = ({
             }
             // In range mode if other value is selected disable items
             // which exceed it.
-            if (otherValue) {
+            if (isValidDate(otherValue)) {
               const currentTimestamp = convertObjectToUnixTimestamp({
                 day: d,
                 month,

--- a/src/components/Datepicker/helpers.js
+++ b/src/components/Datepicker/helpers.js
@@ -175,3 +175,11 @@ export const makeLabelText = (values) => {
     ? `${firstDateLabel} - ${secondDateLabel}`
     : firstDateLabel;
 };
+
+/**
+ * Converts { day, month, year } object to unix second timestamp
+ * uses 23:59 of that day as time.
+ * @param {object} date
+ */
+export const convertObjectToUnixTimestamp = ({ day, month, year }) =>
+  new Date(Date.UTC(year, month - 1, day, 23, 59)).getTime() / 1000;

--- a/src/components/Datepicker/styles.css
+++ b/src/components/Datepicker/styles.css
@@ -318,8 +318,12 @@
   }
 
   .rmpPopup.range {
-    width: 40.6rem;
+    width: 60.6rem;
     padding: 0.6rem;
+  }
+
+  .rmpPopup.range.monthsMode {
+    width: 40.6rem;
   }
 }
 

--- a/src/docs/datepicker.mdx
+++ b/src/docs/datepicker.mdx
@@ -184,10 +184,7 @@ To use the range option, just enable the `isRange` prop. In this case, `value` i
 
 <Playground>
   {() => {
-    const initialValues = [
-      { year: 2019, month: 3, day: 10 },
-      { year: 2020, month: 2, day: 10 }
-    ]
+    const initialValues = null
     const [values, setValues] = useState(initialValues);
     const onChange = (year, month, day, idx) => {
       if (!!year && !!month && !!day) {
@@ -200,6 +197,10 @@ To use the range option, just enable the `isRange` prop. In this case, `value` i
     return (
       <Fragment>
       	<DatePicker
+          years={{
+            min: { day: 1, month: 2, year: 2020 },
+            max: { day: 1, month: 3, year: 2021 }
+          }}
           value={values}
           // enable isRange prop
           isRange={true}

--- a/src/docs/datepicker.mdx
+++ b/src/docs/datepicker.mdx
@@ -180,6 +180,36 @@ To use the range option, just enable the `isRange` prop. In this case, `value` i
   }}
 </Playground>
 
+### date picker with range option
+
+<Playground>
+  {() => {
+    const initialValues = [
+      { year: 2019, month: 3, day: 10 },
+      { year: 2020, month: 2, day: 10 }
+    ]
+    const [values, setValues] = useState(initialValues);
+    const onChange = (year, month, day, idx) => {
+      if (!!year && !!month && !!day) {
+        const newValues = values ? [...values] : []
+        newValues[idx] = { year, month, day }
+        setValues(newValues);
+      }
+    };
+    // specify min, max properties in years object to limit selection
+    return (
+      <Fragment>
+      	<DatePicker
+          value={values}
+          // enable isRange prop
+          isRange={true}
+          onChange={onChange}
+        />
+      </Fragment>
+    );
+  }}
+</Playground>
+
 ### years as array
 
 <Playground>


### PR DESCRIPTION
This improves the date picker `{ day, month, year }` when in range mode:

 - Improve popup width for date picker - Closes #349.
 - Highlight range items - Closes #350.
 - If other value is selected disable items which exceed it.
 
 Before: 
![image](https://user-images.githubusercontent.com/10324528/125981074-aa4d0bdf-c3ec-4844-a955-fda1a5f754fc.png)

After:
![image](https://user-images.githubusercontent.com/10324528/125981221-69b5d113-a633-44d4-a297-353f737699a2.png)

![image](https://user-images.githubusercontent.com/10324528/125981274-16552cd1-d867-41bd-9e5c-1cdd6c1e25fd.png)
