### PR TITLE
Add new layout type to StatusBar

### DIFF
--- a/src/components/StatusBar/StatusBar.jsx
+++ b/src/components/StatusBar/StatusBar.jsx
@@ -10,11 +10,14 @@ const StatusBar = ({
   markerPosition,
   markerTooltipText,
   markerTooltipClassName,
+  renderMarkerComponent,
   max,
   showMarker,
   renderStatusInfoComponent,
   className,
-  decimalPlaces
+  decimalPlaces,
+  layout,
+  showPercent
 }) => {
   const currenttotal = status.reduce((acc, cur) => acc + cur.amount, 0);
   const totalPercentage = max ? (currenttotal / max) * 100 : 100;
@@ -39,8 +42,14 @@ const StatusBar = ({
     ) : (
       <DefaultInfoComp {...props} />
     );
+
   return (
-    <div className={classNames(styles.statusBar, className)}>
+    <div
+      className={classNames(
+        styles.statusBar,
+        className,
+        layout === "balance" && styles.balance
+      )}>
       <div className={styles.statusInfo}>
         <div className={styles.legend}>
           {statusWithPercentages.map((st, i) => (
@@ -48,10 +57,12 @@ const StatusBar = ({
               <div
                 style={{ backgroundColor: st.color }}
                 className={styles.legendColor}
-              />
+              />{" "}
               <span className={styles.legendLabel}>{st.label}:</span>
-              <span className={styles.legendAmount}>{st.amount}</span>
-              <span>({st.percentage}%)</span>
+              {st.renderAmountComponent || (
+                <span className={styles.legendAmount}>{st.amount}</span>
+              )}
+              {showPercent && <span>({st.percentage}%)</span>}
             </div>
           ))}
         </div>
@@ -62,42 +73,48 @@ const StatusBar = ({
           styles.statusWrapper,
           isDarkTheme && styles.statusWrapperDark
         )}>
-        {statusWithPercentages.map((st, i) => (
-          <div
-            key={i + Math.random()}
-            className={classNames(
-              styles.statusOption,
-              i === 0
-                ? styles.firstStatusOption
-                : i === statusWithPercentages.length - 1
-                ? styles.lastStatusOption
-                : null
-            )}
-            style={{
-              width: `${st.widthPercentage}%`,
-              backgroundColor: st.color
-            }}
-          />
-        ))}
-        {showMarker && (
-          <div
-            className={styles.markerWrapper}
-            style={{
-              left: markerPosition
-            }}>
-            <Tooltip
-              content={markerTooltipText || markerPosition}
-              className={styles.markerTooltip}
-              contentClassName={markerTooltipClassName}>
-              <div
-                className={classNames(
-                  styles.marker,
-                  isDarkTheme && styles.markerDark
-                )}
-              />
-            </Tooltip>
-          </div>
-        )}
+        {statusWithPercentages.map((st, i) => {
+          return (
+            <React.Fragment key={i + Math.random()}>
+              {i === 1 &&
+                showMarker &&
+                (renderMarkerComponent || (
+                  <div
+                    className={styles.markerWrapper}
+                    style={{
+                      left: markerPosition
+                    }}>
+                    <Tooltip
+                      content={markerTooltipText || markerPosition}
+                      className={styles.markerTooltip}
+                      contentClassName={markerTooltipClassName}>
+                      <div
+                        className={classNames(
+                          styles.marker,
+                          isDarkTheme && styles.markerDark
+                        )}
+                      />
+                    </Tooltip>
+                  </div>
+                ))}
+              {layout === "balance" ? (
+                <div>
+                  <StatusOption
+                    percentage={st.widthPercentage}
+                    color={st.color}
+                    className={styles.statusOption}
+                  />
+                </div>
+              ) : (
+                <StatusOption
+                  percentage={st.widthPercentage}
+                  color={st.color}
+                  className={styles.statusOption}
+                />
+              )}
+            </React.Fragment>
+          );
+        })}
       </div>
     </div>
   );
@@ -115,23 +132,44 @@ DefaultInfoComp.propTypes = {
   max: PropTypes.number
 };
 
+const StatusOption = ({ percentage, color, className }) => (
+  <div
+    className={className}
+    style={{
+      width: `${percentage}%`,
+      backgroundColor: color
+    }}
+  />
+);
+
+StatusOption.propTypes = {
+  percentage: PropTypes.number,
+  color: PropTypes.string,
+  className: PropTypes.string
+};
+
 StatusBar.propTypes = {
   status: PropTypes.array.isRequired,
   markerPosition: PropTypes.string,
   markerTooltipText: PropTypes.string,
   markerTooltipClassName: PropTypes.string,
+  renderMarkerComponent: PropTypes.element,
   renderStatusInfoComponent: PropTypes.element,
   max: PropTypes.number,
   showMarker: PropTypes.bool,
   className: PropTypes.string,
-  decimalPlaces: PropTypes.number
+  decimalPlaces: PropTypes.number,
+  layout: PropTypes.string,
+  showPercent: PropTypes.bool
 };
 
 StatusBar.defaultProps = {
   markerPosition: "0%",
   max: 0,
   showMarker: true,
-  decimalPlaces: 1
+  decimalPlaces: 1,
+  layout: "default",
+  showPercent: true
 };
 
 export default StatusBar;

--- a/src/components/StatusBar/styles.css
+++ b/src/components/StatusBar/styles.css
@@ -8,6 +8,17 @@
   position: relative;
   border: 1px solid var(--color-gray-light);
   border-radius: 10rem;
+  height: 10px;
+}
+
+.statusBar.balance .statusWrapper > div {
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+}
+
+.statusBar.balance .statusWrapper > div:first-of-type {
+  justify-content: flex-end;
 }
 
 .statusWrapperDark {
@@ -42,6 +53,12 @@
   margin-right: 3rem;
 }
 
+.statusBar.balance .legendLine:last-of-type {
+  position: absolute;
+  left: 50%;
+  padding-left: 35px;
+}
+
 .legend {
   composes: infoCurrent;
   display: flex;
@@ -69,12 +86,16 @@
   height: 8px;
 }
 
-.firstStatusOption {
+.statusOption:first-of-type {
   border-radius: 10rem 0 0 10rem;
 }
 
-.lastStatusOption {
+.statusOption:last-of-type {
   border-radius: 0 10rem 10rem 0;
+}
+
+.statusBar.balance .statusWrapper > div:first-of-type .statusOption {
+  border-radius: 10rem 0 0 10rem;
 }
 
 .markerWrapper {

--- a/src/components/StatusBar/test/__snapshots__/statusBar.test.js.snap
+++ b/src/components/StatusBar/test/__snapshots__/statusBar.test.js.snap
@@ -21,6 +21,7 @@ exports[`StatusBar component Matches the snapshot 1`] = `
             }
           }
         />
+         
         <span
           className="legendLabel"
         >
@@ -49,6 +50,7 @@ exports[`StatusBar component Matches the snapshot 1`] = `
             }
           }
         />
+         
         <span
           className="legendLabel"
         >
@@ -86,20 +88,11 @@ exports[`StatusBar component Matches the snapshot 1`] = `
     className="statusWrapper"
   >
     <div
-      className="statusOption firstStatusOption"
+      className="statusOption"
       style={
         Object {
           "backgroundColor": "green",
           "width": "60%",
-        }
-      }
-    />
-    <div
-      className="statusOption lastStatusOption"
-      style={
-        Object {
-          "backgroundColor": "orange",
-          "width": "40%",
         }
       }
     />
@@ -125,6 +118,15 @@ exports[`StatusBar component Matches the snapshot 1`] = `
         />
       </div>
     </div>
+    <div
+      className="statusOption"
+      style={
+        Object {
+          "backgroundColor": "orange",
+          "width": "40%",
+        }
+      }
+    />
   </div>
 </div>
 `;

--- a/src/docs/statusbar.mdx
+++ b/src/docs/statusbar.mdx
@@ -5,7 +5,7 @@ route: /components/statusbar
 ---
 
 import { Playground, Props } from "docz";
-import { StatusBar } from "../index";
+import { StatusBar, Icon } from "../index";
 import styles from "../css/base.css";
 import { classNames } from "../utils";
 
@@ -93,5 +93,31 @@ import { classNames } from "../utils";
     ]}
     renderStatusInfoComponent={<div>I am custom</div>}
     showMarker={false}
+  />
+  <br/>
+  <br/>
+  <StatusBar
+    status = {[
+      {
+        label: "Local",
+        amount: 9.45931345,
+        color: "green",
+        renderAmountComponent: <span>9.45931345 DCR</span>
+      },
+      {
+        label: "Remote",
+        amount: 1.45931345,
+        color: "orange",
+        renderAmountComponent: <span>1.45931345 DCR</span>
+      }
+    ]}
+    markerPosition = "50%"
+    max={10.9431937482}
+    layout="balance"
+    showPercent={false}
+    renderStatusInfoComponent={<div/>}
+    renderMarkerComponent={<div style={{width:"35px",height:"35px",maxWidth:"35px",marginTop:"-13px", backgroundColor:"white",display:"flex", justifyContent:"center", alignItems:"center"}}>
+                              <Icon type="checkmark" size="md" />
+                           </div>}
   />
 </Playground>


### PR DESCRIPTION
I am working on https://github.com/decred/decrediton/pull/3543, which could use the StatusBar component.
It needed a new type of layout, and this diff implements it. 

Screenshots from Decrediton:
<img width="591" alt="DeepinScreenshot_select-area_20210902164630" src="https://user-images.githubusercontent.com/52497040/131865232-3911879c-fe0d-4f34-88d8-88f8996f2b39.png">

