### PR TITLE
Improve customizability of `Tabs` component

### DIFF
--- a/src/components/Tabs/Tab.jsx
+++ b/src/components/Tabs/Tab.jsx
@@ -25,7 +25,7 @@ const Tab = ({
   const customTheme = {
     ...theme,
     ...themes
-  }
+  };
   const activeBorderColor = getThemeProperty(customTheme, "tab-active-color");
   const defaultBorderColor = getThemeProperty(customTheme, "tab-default-color");
   const activeBackgroundColor = getThemeProperty(customTheme, "tab-active-background");

--- a/src/components/Tabs/Tab.jsx
+++ b/src/components/Tabs/Tab.jsx
@@ -14,7 +14,6 @@ const Tab = ({
   label,
   count,
   mode,
-  themes,
   ...props
 }) => {
   const { theme } = useTheme();
@@ -22,17 +21,12 @@ const Tab = ({
     e.preventDefault();
     onSelect(tabIndex);
   };
-  const customTheme = {
-    ...theme,
-    ...themes
-  };
-  const activeBorderColor = getThemeProperty(customTheme, "tab-active-color");
-  const defaultBorderColor = getThemeProperty(customTheme, "tab-default-color");
-  const activeBackgroundColor = getThemeProperty(customTheme, "tab-active-background");
-  const defaultBackgroundColor = getThemeProperty(customTheme, "tab-default-background");
-  const activeTextColor = getThemeProperty(customTheme, "tab-text-active-color");
-  const defaultTextColor = getThemeProperty(customTheme, "tab-text-color");
-
+  const activeBorderColor = getThemeProperty(theme, "tab-active-color");
+  const defaultBorderColor = getThemeProperty(theme, "tab-default-color");
+  const activeBackgroundColor = getThemeProperty(theme, "tab-active-background");
+  const defaultBackgroundColor = getThemeProperty(theme, "tab-default-background");
+  const activeTextColor = getThemeProperty(theme, "tab-text-active-color");
+  const defaultTextColor = getThemeProperty(theme, "tab-text-color");
   const slide = useSpring({
     borderColor: isActive ? activeBorderColor : defaultBorderColor,
     color: isActive ? activeTextColor : defaultTextColor,
@@ -72,8 +66,7 @@ Tab.propTypes = {
   style: PropTypes.object,
   label: PropTypes.node,
   count: PropTypes.node,
-  mode: PropTypes.oneOf(["horizontal", "vertical", "dropdown"]),
-  themes: PropTypes.object
+  mode: PropTypes.oneOf(["horizontal", "vertical", "dropdown"])
 };
 
 Tab.defaultProps = {

--- a/src/components/Tabs/Tab.jsx
+++ b/src/components/Tabs/Tab.jsx
@@ -22,30 +22,17 @@ const Tab = ({
     e.preventDefault();
     onSelect(tabIndex);
   };
-  const activeBorderColor = getThemeProperty(
-    theme,
-    themes?.tabActiveBorderColor || "tab-active-color"
-  );
-  const defaultBorderColor = getThemeProperty(
-    theme,
-    themes?.tabDefaultBorderColor || "tab-default-color"
-  );
-  const activeBackgroundColor = getThemeProperty(
-    theme,
-    themes?.tabActiveBackgroundColor || "tab-active-background"
-  );
-  const defaultBackgroundColor = getThemeProperty(
-    theme,
-    themes?.tabDefaultBackgroundColor || "tab-default-background"
-  );
-  const activeTextColor = getThemeProperty(
-    theme,
-    themes?.tabActiveTextColor || "tab-text-active-color"
-  );
-  const defaultTextColor = getThemeProperty(
-    theme,
-    themes?.tabDefaultTextColor || "tab-text-color"
-  );
+  const customTheme = {
+    ...theme,
+    ...themes
+  }
+  const activeBorderColor = getThemeProperty(customTheme, "tab-active-color");
+  const defaultBorderColor = getThemeProperty(customTheme, "tab-default-color");
+  const activeBackgroundColor = getThemeProperty(customTheme, "tab-active-background");
+  const defaultBackgroundColor = getThemeProperty(customTheme, "tab-default-background");
+  const activeTextColor = getThemeProperty(customTheme, "tab-text-active-color");
+  const defaultTextColor = getThemeProperty(customTheme, "tab-text-color");
+
   const slide = useSpring({
     borderColor: isActive ? activeBorderColor : defaultBorderColor,
     color: isActive ? activeTextColor : defaultTextColor,

--- a/src/components/Tabs/Tab.jsx
+++ b/src/components/Tabs/Tab.jsx
@@ -14,6 +14,7 @@ const Tab = ({
   label,
   count,
   mode,
+  themes,
   ...props
 }) => {
   const { theme } = useTheme();
@@ -21,12 +22,30 @@ const Tab = ({
     e.preventDefault();
     onSelect(tabIndex);
   };
-  const activeBorderColor = getThemeProperty(theme, "tab-active-color");
-  const defaultBorderColor = getThemeProperty(theme, "tab-default-color");
-  const activeBackgroundColor = getThemeProperty(theme, "tab-active-background");
-  const defaultBackgroundColor = getThemeProperty(theme, "tab-default-background");
-  const activeTextColor = getThemeProperty(theme, "tab-text-active-color");
-  const defaultTextColor = getThemeProperty(theme, "tab-text-color");
+  const activeBorderColor = getThemeProperty(
+    theme,
+    themes?.tabActiveBorderColor || "tab-active-color"
+  );
+  const defaultBorderColor = getThemeProperty(
+    theme,
+    themes?.tabDefaultBorderColor || "tab-default-color"
+  );
+  const activeBackgroundColor = getThemeProperty(
+    theme,
+    themes?.tabActiveBackgroundColor || "tab-active-background"
+  );
+  const defaultBackgroundColor = getThemeProperty(
+    theme,
+    themes?.tabDefaultBackgroundColor || "tab-default-background"
+  );
+  const activeTextColor = getThemeProperty(
+    theme,
+    themes?.tabActiveTextColor || "tab-text-active-color"
+  );
+  const defaultTextColor = getThemeProperty(
+    theme,
+    themes?.tabDefaultTextColor || "tab-text-color"
+  );
   const slide = useSpring({
     borderColor: isActive ? activeBorderColor : defaultBorderColor,
     color: isActive ? activeTextColor : defaultTextColor,
@@ -66,7 +85,8 @@ Tab.propTypes = {
   style: PropTypes.object,
   label: PropTypes.node,
   count: PropTypes.node,
-  mode: PropTypes.oneOf(["horizontal", "vertical", "dropdown"])
+  mode: PropTypes.oneOf(["horizontal", "vertical", "dropdown"]),
+  themes: PropTypes.object
 };
 
 Tab.defaultProps = {

--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -39,7 +39,6 @@ const Tabs = ({
   mode,
   contentClassName,
   contentAnimation,
-  themes,
   ...props
 }) => {
   const dropdownMode = mode === "dropdown";
@@ -55,7 +54,6 @@ const Tabs = ({
           tabIndex: index,
           isActive: index === activeTabIndex,
           mode,
-          themes
         });
         return dropdownMode ? (
           <DropdownItem className={styles.customDropdownItem}>
@@ -65,7 +63,7 @@ const Tabs = ({
           element
         );
       });
-  }, [children, activeTabIndex, mode, onSelectTab, dropdownMode, themes]);
+  }, [children, activeTabIndex, mode, onSelectTab, dropdownMode]);
 
   const tabs = useMemo(
     () => (
@@ -192,7 +190,6 @@ Tabs.propTypes = {
   mode: PropTypes.oneOf(["horizontal", "vertical", "dropdown"]),
   contentAnimation: PropTypes.oneOf(["none", "fade", "slide"]),
   contentClassName: PropTypes.string,
-  themes: PropTypes.object
 };
 
 Tabs.defaultProps = {

--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -5,6 +5,7 @@ import { classNames } from "../../utils";
 import styles from "./styles.css";
 import Dropdown from "../Dropdown/Dropdown.jsx";
 import DropdownItem from "../Dropdown/DropdownItem.jsx";
+import { usePrevious } from "../../hooks";
 
 const TabDropdownTrigger = ({
   onClick,
@@ -37,10 +38,13 @@ const Tabs = ({
   wrap,
   mode,
   contentClassName,
+  contentAnimation,
+  themes,
   ...props
 }) => {
   const dropdownMode = mode === "dropdown";
   const vertical = mode === "vertical" || dropdownMode;
+  const previousActiveTabIndex = usePrevious(activeTabIndex);
   const renderChildrenTabs = useCallback(() => {
     return React.Children.toArray(children)
       .filter(Boolean)
@@ -50,7 +54,8 @@ const Tabs = ({
           onSelect: onSelectTab,
           tabIndex: index,
           isActive: index === activeTabIndex,
-          mode
+          mode,
+          themes
         });
         return dropdownMode ? (
           <DropdownItem className={styles.customDropdownItem}>
@@ -60,7 +65,7 @@ const Tabs = ({
           element
         );
       });
-  }, [children, activeTabIndex, mode, onSelectTab, dropdownMode]);
+  }, [children, activeTabIndex, mode, onSelectTab, dropdownMode, themes]);
 
   const tabs = useMemo(
     () => (
@@ -88,14 +93,58 @@ const Tabs = ({
     );
   };
 
-  const transition = useTransition(activeTabIndex, {
-    initial: { position: "absolute", opacity: 1 },
-    from: { position: "absolute", opacity: 0 },
-    enter: { opacity: 1 },
-    leave: { opacity: 0 },
-    config: { duration: 350 },
-    keys: (item) => item
-  });
+  const dir = previousActiveTabIndex > activeTabIndex ? "l2r" : "r2l";
+  const slideMaxPosition = 1000;
+  const transition =
+    contentAnimation === "slide"
+      ? useTransition(activeTabIndex, {
+          initial: {
+            position: "absolute",
+            overflowY: "hidden",
+            opacity: 0,
+            left: "40px",
+            right: "40px"
+          },
+          from: {
+            position: "absolute",
+            overflowY: "hidden",
+            opacity: 0,
+            left:
+              dir === "r2l"
+                ? `${slideMaxPosition}px`
+                : `-${slideMaxPosition}px`,
+            right:
+              dir === "r2l" ? `-${slideMaxPosition}px` : `${slideMaxPosition}px`
+          },
+          enter: () => [
+            { left: "0px", right: "0px", opacity: 1, overflowY: "hidden" },
+            { overflowY: "auto" }
+          ],
+          leave: () => async (next) => {
+            await next({ overflowY: "hidden" });
+            await next({
+              opacity: 0,
+              left:
+                dir === "r2l"
+                  ? `-${slideMaxPosition}px`
+                  : `${slideMaxPosition}px`,
+              right:
+                dir === "r2l"
+                  ? `${slideMaxPosition}px`
+                  : `-${slideMaxPosition}px`
+            });
+          },
+          config: { mass: 1, tension: 210, friction: 26 },
+          key: children[activeTabIndex]?.props?.children?.key
+        })
+      : useTransition(activeTabIndex, {
+          initial: { position: "absolute", opacity: 1 },
+          from: { position: "absolute", opacity: 0 },
+          enter: { opacity: 1 },
+          leave: { opacity: 0 },
+          config: { duration: 350 },
+          keys: (item) => item
+        });
 
   return (
     <>
@@ -110,11 +159,17 @@ const Tabs = ({
       ) : (
         tabs
       )}
-      {transition((style, item) => (
-        <animated.div style={style} className={contentClassName}>
-          {children[item] && children[item].props.children}
-        </animated.div>
-      ))}
+      {contentAnimation === "none" ? (
+        <div className={contentClassName}>
+          {children[activeTabIndex] && children[activeTabIndex].props.children}
+        </div>
+      ) : (
+        transition((contentStyle, item) => (
+          <animated.div style={contentStyle} className={contentClassName}>
+            {children[item] && children[item].props.children}
+          </animated.div>
+        ))
+      )}
     </>
   );
 };
@@ -135,12 +190,15 @@ Tabs.propTypes = {
   children: PropTypes.node.isRequired,
   wrap: PropTypes.bool,
   mode: PropTypes.oneOf(["horizontal", "vertical", "dropdown"]),
-  contentClassName: PropTypes.string
+  contentAnimation: PropTypes.oneOf(["none", "fade", "slide"]),
+  contentClassName: PropTypes.string,
+  themes: PropTypes.object
 };
 
 Tabs.defaultProps = {
   wrap: false,
-  mode: "horizontal"
+  mode: "horizontal",
+  contentAnimation: "fade"
 };
 
 export default Tabs;

--- a/src/docs/tabs.mdx
+++ b/src/docs/tabs.mdx
@@ -158,36 +158,3 @@ import { Tabs, Tab } from "../index";
     );
   }}
 </Playground>
-
-### Tabs with custom colors
-
-<Playground>
-  {() => {
-    const [activeTabIndex, setActiveTabIndex] = useState(0);
-    const themes = {
-      "tab-active-color": "gray",
-      "tab-default-color": "lightgray",
-      "tab-active-background": "lightgray",
-      "tab-default-background": "lightgray",
-      "tab-text-active-color": "black",
-      "tab-text-color": "gray",
-    }
-    return (
-      <Fragment>
-        <div style={{ backgroundColor: "lightgray", padding: "40px"}}>
-          <Tabs onSelectTab={setActiveTabIndex} activeTabIndex={activeTabIndex} themes={themes}>
-              <Tab label="tab 1" >
-                  <div key={1}>tab content 1</div>
-              </Tab>
-              <Tab label="tab 2" >
-                  <div key={2}>tab content 2</div>
-              </Tab>
-              <Tab label="tab 3" >
-                  <div key={3}>tab content 3</div>
-              </Tab>
-          </Tabs>
-        </div>
-      </Fragment>
-    );
-  }}
-</Playground>

--- a/src/docs/tabs.mdx
+++ b/src/docs/tabs.mdx
@@ -158,3 +158,36 @@ import { Tabs, Tab } from "../index";
     );
   }}
 </Playground>
+
+### Tabs with custom colors
+
+<Playground>
+  {() => {
+    const [activeTabIndex, setActiveTabIndex] = useState(0);
+    const themes = {
+      "tab-active-color": "gray",
+      "tab-default-color": "lightgray",
+      "tab-active-background": "lightgray",
+      "tab-default-background": "lightgray",
+      "tab-text-active-color": "black",
+      "tab-text-color": "gray",
+    }
+    return (
+      <Fragment>
+        <div style={{ backgroundColor: "lightgray", padding: "40px"}}>
+          <Tabs onSelectTab={setActiveTabIndex} activeTabIndex={activeTabIndex} themes={themes}>
+              <Tab label="tab 1" >
+                  <div key={1}>tab content 1</div>
+              </Tab>
+              <Tab label="tab 2" >
+                  <div key={2}>tab content 2</div>
+              </Tab>
+              <Tab label="tab 3" >
+                  <div key={3}>tab content 3</div>
+              </Tab>
+          </Tabs>
+        </div>
+      </Fragment>
+    );
+  }}
+</Playground>

--- a/src/docs/tabs.mdx
+++ b/src/docs/tabs.mdx
@@ -107,4 +107,54 @@ import { Tabs, Tab } from "../index";
     
 </Playground>
 
+### Tabs with slide content animation
 
+<Playground >
+  {() => {
+    const [activeTabIndex, setActiveTabIndex] = useState(0);
+    return (
+      <div style={{ overflow: "hidden", position: "relative", height: "80px" }}>
+        <Tabs onSelectTab={setActiveTabIndex} activeTabIndex={activeTabIndex} contentAnimation="slide">
+            <Tab label="tab 1" count={1}>
+                <div key={1}>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam sit amet est sed urna sollicitudin imperdiet vitae eu massa. 
+                </div>
+            </Tab>
+            <Tab label="tab 2" count={4} >
+                <div key={2}>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam sit amet est sed urna sollicitudin imperdiet vitae eu massa. 
+                </div>
+            </Tab>
+            <Tab label="tab 3">
+                <div key={3}>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam sit amet est sed urna sollicitudin imperdiet vitae eu massa. 
+                </div>
+            </Tab>
+        </Tabs>
+      </div>
+    );
+  }}
+</Playground>
+
+### Tabs without content animation
+
+<Playground>
+  {() => {
+    const [activeTabIndex, setActiveTabIndex] = useState(0);
+    return (
+      <Fragment>
+        <Tabs onSelectTab={setActiveTabIndex} activeTabIndex={activeTabIndex} contentAnimation="none">
+            <Tab label="tab 1" count={1}>
+                <div key={1}>tab content 1</div>
+            </Tab>
+            <Tab label="tab 2" count={4} >
+                <div key={2}>tab content 2</div>
+            </Tab>
+            <Tab label="tab 3" >
+                <div key={3}>tab content 3</div>
+            </Tab>
+        </Tabs>
+      </Fragment>
+    );
+  }}
+</Playground>

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -4,3 +4,4 @@ export { default as useHover } from "./useHover";
 export { default as useClickOutside } from "./useClickOutside";
 export { default as useLockBodyScrollOnTrue } from "./useLockBodyScrollOnTrue";
 export { default as useMountEffect } from "./useMountEffect";
+export { default as usePrevious } from "./usePrevious";

--- a/src/hooks/usePrevious.js
+++ b/src/hooks/usePrevious.js
@@ -1,0 +1,11 @@
+import { useRef, useEffect } from "react";
+
+function usePrevious(value) {
+  const ref = useRef();
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+}
+
+export default usePrevious;

--- a/yarn.lock
+++ b/yarn.lock
@@ -16446,9 +16446,9 @@ ws@^6.0.0, ws@^6.2.1:
     async-limiter "~1.0.0"
 
 ws@^7.0.0:
-  version "7.5.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.3.tgz#160835b63c7d97bfab418fc1b8a9fced2ac01a74"
-  integrity sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.2.tgz#782100048e54eb36fe9843363ab1c68672b261dd"
+  integrity sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==
 
 x-is-string@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
decred/decrediton#3592 needs additional customization for `Tabs` and `Tab` component.

This diff adds:
- the ability for content animation to be changed to "slide" or "none".  The default animation remained "fade" type.
- plus theming ability to `Tabs` color.
