### PR TITLE
TextHighlighted component

### DIFF
--- a/src/components/CopyableText/CopyableText.jsx
+++ b/src/components/CopyableText/CopyableText.jsx
@@ -1,11 +1,11 @@
 import PropTypes from "prop-types";
 import React, { useState } from "react";
-import Text from "../Typography/Text/Text.jsx";
 import { copyToClipboard as copy } from "./helpers";
 import { classNames, idPropTypeCheckForTruncatedComponents } from "../../utils";
 import styles from "./styles.css";
 import Tooltip from "../Tooltip/Tooltip.jsx";
 import Icon from "../Icon/Icon.jsx";
+import TextHighlighted from "../TextHighlighted/TextHighlighted.jsx";
 
 const CopyableText = ({
   id,
@@ -30,13 +30,13 @@ const CopyableText = ({
   };
   return (
     <div className={classNames(styles.copyableWrapper, className)} {...props}>
-      <Text
+      <TextHighlighted
         id={id}
         truncate={truncate}
-        className={classNames(styles.contentWrapper, textClassName)}
+        className={textClassName}
         style={textStyle}>
         {children}
-      </Text>
+      </TextHighlighted>
       <Tooltip
         placement={tooltipPlacement}
         content={feedbackActive ? "Copied!" : hoverText}>

--- a/src/components/CopyableText/styles.css
+++ b/src/components/CopyableText/styles.css
@@ -5,13 +5,6 @@
   max-width: 100%;
 }
 
-.contentWrapper {
-  padding: 0.3rem 1rem;
-  word-break: break-all;
-  background-color: var(--copyable-text-background-color);
-  border-radius: 0.4rem;
-}
-
 .copyToClipboard {
   width: 1.4rem;
   height: 1.4rem;

--- a/src/components/TextHighlighted/TextHighlighted.jsx
+++ b/src/components/TextHighlighted/TextHighlighted.jsx
@@ -1,0 +1,32 @@
+import PropTypes from "prop-types";
+import React from "react";
+import Text from "../Typography/Text/Text.jsx";
+import { classNames, idPropTypeCheckForTruncatedComponents } from "../../utils";
+import styles from "./styles.css";
+
+const TextHighlighted = ({ id, truncate, className, style, children }) => (
+  <Text
+    {...{
+      id,
+      truncate,
+      style,
+      className: classNames(styles.contentWrapper, className),
+    }}
+    style={style}>
+    {children}
+  </Text>
+);
+
+TextHighlighted.propTypes = {
+  id: idPropTypeCheckForTruncatedComponents,
+  truncate: PropTypes.bool,
+  className: PropTypes.string,
+  style: PropTypes.object,
+  children: PropTypes.node,
+};
+
+TextHighlighted.defaultProps = {
+  truncate: true,
+};
+
+export default TextHighlighted;

--- a/src/components/TextHighlighted/styles.css
+++ b/src/components/TextHighlighted/styles.css
@@ -1,0 +1,6 @@
+.contentWrapper {
+  padding: 0.3rem 1rem;
+  word-break: break-all;
+  background-color: var(--copyable-text-background-color);
+  border-radius: 0.4rem;
+}

--- a/src/components/TextHighlighted/tests/__snapshots__/texthighlighted.test.js.snap
+++ b/src/components/TextHighlighted/tests/__snapshots__/texthighlighted.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextHighlighted component Matches snapshot 1`] = `
+<span
+  className="text textAlignStart weightRegular sizeNormal colorDefault contentWrapper"
+  id="text-id"
+>
+  test
+</span>
+`;

--- a/src/components/TextHighlighted/tests/texthighlighted.test.js
+++ b/src/components/TextHighlighted/tests/texthighlighted.test.js
@@ -1,0 +1,21 @@
+import React from "react";
+import TextHighlighted from "../TextHighlighted";
+import { create } from "react-test-renderer";
+import {
+  defaultLightTheme,
+  ThemeProvider,
+  DEFAULT_LIGHT_THEME_NAME,
+} from "../../../theme";
+
+describe("TextHighlighted component", () => {
+  test("Matches snapshot", () => {
+    const texthighlighted = create(
+      <ThemeProvider
+        themes={{ [DEFAULT_LIGHT_THEME_NAME]: defaultLightTheme }}
+        defaultThemeName={DEFAULT_LIGHT_THEME_NAME}>
+        <TextHighlighted id="text-id">test</TextHighlighted>
+      </ThemeProvider>
+    );
+    expect(texthighlighted.toJSON()).toMatchSnapshot();
+  });
+});

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -120,3 +120,11 @@ CopyableText accepts classNames for text and button
   width: 2rem !important;
   height: 2rem !important;
 }
+
+/*
+TextHighlighted accepts classNames for text 
+*/
+
+.textHighlighted {
+  padding: 1rem 10rem !important;
+}

--- a/src/docs/texthighlighted.mdx
+++ b/src/docs/texthighlighted.mdx
@@ -1,0 +1,28 @@
+---
+name: TextHighlighted
+menu: Components
+route: /components/texthighlighted
+---
+
+
+import { Playground, Props } from "docz";
+import { TextHighlighted } from "../index";
+import styles from "../css/base.css";
+
+# TextHighlighted
+
+## Properties
+
+<Props of={TextHighlighted} />
+
+## Usage
+
+<Playground>
+  <TextHighlighted>Highlighted Text</TextHighlighted>
+</Playground>
+
+### Custom classNames
+
+<Playground>
+  <TextHighlighted className={styles.textHighlighted}>DsmNwrL7C2J546Zr9qwEdsTr85WMKWNHDCr</TextHighlighted>
+</Playground>

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ export { default as Select } from "./components/Select/Select.jsx";
 export { default as DatePicker } from "./components/Datepicker/Datepicker.jsx";
 export { default as Slider } from "./components/Slider/Slider.jsx";
 export { default as Paginator } from "./components/Paginator/Paginator.jsx";
+export { default as TextHighlighted } from "./components/TextHighlighted/TextHighlighted.jsx";
 export * from "./hooks";
 export * from "./theme";
 export * from "./utils";


### PR DESCRIPTION
Closes #390

This diff introduces a new component named `TextHighlighted` which is essentially the text part of `CopyableText` component. It is imported and used on `CopyableText` and exported for external usage also. 

Decrediton uses this component for displaying balance on various headers and for displaying the address on the Transaction History view.

<img width="338" alt="image" src="https://user-images.githubusercontent.com/52497040/143680475-afc7f3a8-0ede-4df6-9b2f-07c8cb0f0c7d.png">
