### PR TITLE
feat(theme): Add Default Theme

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,4 @@
 import { addDecorator } from "@storybook/react";
-import themeDecorator from "./themeDecorator";
 import { withThemes } from "@react-theming/storybook-addon";
 import {
   DEFAULT_DARK_THEME_NAME,

--- a/.storybook/providerFn.js
+++ b/.storybook/providerFn.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import {
   useTheme,
   ThemeProvider,

--- a/src/components/Datepicker/test/__snapshots__/datepicker.test.js.snap
+++ b/src/components/Datepicker/test/__snapshots__/datepicker.test.js.snap
@@ -39,7 +39,7 @@ exports[`DatePicker component Matches the snapshot 1`] = `
       className="rmpCell"
     >
       <div
-        className="rmpPopup"
+        className="rmpPopup light"
       />
     </div>
   </div>

--- a/src/components/Icon/Icon.jsx
+++ b/src/components/Icon/Icon.jsx
@@ -989,7 +989,7 @@ const icons = (type, backgroundColor, iconColor) => {
     ),
     cancel: (
       <>
-        <g clip-path="url(#clip0_10_15)">
+        <g clipPath="url(#clip0_10_15)">
           <path d="M141.229 140.771L309.687 309.229Z" fill={iconColor} />
           <path d="M141.229 309.229L309.687 140.771Z" fill={iconColor} />
           <path

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import "./css/base.css";
+import "./theme/defaultTheme.js";
 
 export { default as BoxTextInput } from "./components/BoxTextInput/BoxTextInput.jsx";
 export { default as Button } from "./components/Button/Button.jsx";

--- a/src/theme/ThemeProvider.js
+++ b/src/theme/ThemeProvider.js
@@ -6,8 +6,14 @@ import React, {
   useContext,
 } from "react";
 import PropTypes from "prop-types";
+import defaultLightTheme from "./lightTheme";
+import { DEFAULT_LIGHT_THEME_NAME } from "./constants";
 
-const ThemeContext = createContext();
+const ThemeContext = createContext({
+  theme: defaultLightTheme,
+  themeName: DEFAULT_LIGHT_THEME_NAME,
+  setThemeName: () => {},
+});
 
 export const useTheme = () => useContext(ThemeContext) || {};
 
@@ -20,9 +26,7 @@ export const ThemeProvider = ({
   const [themeName, setThemeName] = useState(defaultThemeName);
   const theme = useMemo(() => themes[themeName], [themes, themeName]);
   useLayoutEffect(() => {
-    Object.keys(theme).forEach((key) => {
-      document.documentElement.style.setProperty(`--${key}`, theme[key]);
-    });
+    applyTheme(theme);
     if (fonts) {
       applyFontAsset(fonts);
     }
@@ -71,3 +75,9 @@ const applyFontAsset = (fonts) => {
   newStyle.type = "text/css";
   document.head.appendChild(newStyle);
 };
+
+function applyTheme(theme) {
+  Object.keys(theme).forEach((key) => {
+    document.documentElement.style.setProperty(`--${key}`, theme[key]);
+  });
+}

--- a/src/theme/defaultTheme.js
+++ b/src/theme/defaultTheme.js
@@ -1,0 +1,9 @@
+import lightTheme from "./lightTheme";
+
+function applyDefaultTheme() {
+  Object.keys(lightTheme).forEach((key) => {
+    document.documentElement.style.setProperty(`--${key}`, lightTheme[key]);
+  });
+}
+
+applyDefaultTheme();


### PR DESCRIPTION
Closes #426 

This diff adds default theme variables to our components, so
we can import and use them without needing to use the 
`ThemeProvider` provider.

Themes are still customizable, but if we don't wrap our components,
the behavior should still be the same.

Before:
<img width="128" alt="Screen Shot 2022-04-07 at 6 37 18 PM" src="https://user-images.githubusercontent.com/22639213/162324141-b6bbd152-4fcd-4ca0-beb6-41e78ac285cc.png">

After:
<img width="153" alt="Screen Shot 2022-04-07 at 6 38 38 PM" src="https://user-images.githubusercontent.com/22639213/162324297-1f8306b9-748c-4560-b8e1-c8b89f6a000c.png">

