### PR TITLE
[v2] datepicker: persist value on pad

### DIFF
--- a/src/components/Datepicker/DatepickerPadv2.jsx
+++ b/src/components/Datepicker/DatepickerPadv2.jsx
@@ -101,9 +101,9 @@ function DatePickerPad({
     year: now.getFullYear(),
   };
 
-  const [currentDate, setCurrentDate] = useState(today || value);
-  const [selectedDate, setSelectedDate] = useState();
-  // const [hoverId, setHoverId] = useState(undefined);
+  const [currentDate, setCurrentDate] = useState(value || today);
+  const [selectedDate, setSelectedDate] = useState(value);
+
   const [selectedCoords, setSelectedCoords] = useState();
   // Number of days from current month and year
   const daysLength = new Date(currentDate.year, currentDate.month, 0).getDate();

--- a/src/stories/DatePickerV2.stories.jsx
+++ b/src/stories/DatePickerV2.stories.jsx
@@ -10,7 +10,7 @@ const DatePickerV2Obj = {
 export default DatePickerV2Obj;
 
 const ControlledTemplate = ({ children, ...args }) => {
-  const [value, setValue] = useState({ year: 2022, month: 5, day: 15 });
+  const [value, setValue] = useState();
 
   return <DatePickerV2 {...args} value={value} onChange={setValue} />;
 };


### PR DESCRIPTION
This diff fixes the non-persistent data on datepicker pad. Previously,
the datepicker pad v2 cleared the selected date on dismiss/change.