### PR TITLE
[multi] Fix tabs with slide animation initial appearance

### DIFF
--- a/src/components/RadioButtonGroup/RadioButtonGroup.jsx
+++ b/src/components/RadioButtonGroup/RadioButtonGroup.jsx
@@ -103,7 +103,7 @@ export const RadioButtonGroup = ({
             checked={option.value === value}
             label={option.label}
             name={name}
-            id={`radio-btn-${idx}`}
+            id={`radio-btn-${idx}${name ? `-${name}` : ""}`}
             disabled={disabled}
             description={vertical && option.description}
           />

--- a/src/components/RadioButtonGroup/tests/__snapshots__/radiobuttongroup.test.js.snap
+++ b/src/components/RadioButtonGroup/tests/__snapshots__/radiobuttongroup.test.js.snap
@@ -1,5 +1,95 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RadioButtonGroup component Matches snapshot (set name property) 1`] = `
+<div
+  className="radioGroup"
+>
+  <label
+    className="radioGroupLabel"
+  >
+    Test
+  </label>
+  <ul
+    className="radioGroupList"
+  >
+    <li>
+       
+      <div
+        className="radioButton"
+      >
+        <input
+          checked={true}
+          disabled={false}
+          id="radio-btn-0-name"
+          name="name"
+          onChange={[Function]}
+          type="radio"
+        />
+        <label
+          htmlFor="radio-btn-0-name"
+          onClick={[Function]}
+        >
+          <span
+            className="circle checked"
+          >
+            <span
+              className="dot"
+              style={
+                Object {
+                  "transform": " scale(1)",
+                }
+              }
+            />
+          </span>
+          <label
+            className="radioButtonOptionLabel"
+          >
+            foo
+          </label>
+        </label>
+      </div>
+    </li>
+    <li>
+       
+      <div
+        className="radioButton"
+      >
+        <input
+          checked={false}
+          disabled={false}
+          id="radio-btn-1-name"
+          name="name"
+          onChange={[Function]}
+          type="radio"
+        />
+        <label
+          htmlFor="radio-btn-1-name"
+          onClick={[Function]}
+        >
+          <span
+            className="circle"
+          >
+            <span
+              className="dot"
+              style={
+                Object {
+                  "transform": " scale(0)",
+                }
+              }
+            />
+          </span>
+          <label
+            className="radioButtonOptionLabel"
+          >
+            bar
+          </label>
+        </label>
+      </div>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`RadioButtonGroup component Matches snapshot 1`] = `
 <div
   className="radioGroup"

--- a/src/components/RadioButtonGroup/tests/radiobuttongroup.test.js
+++ b/src/components/RadioButtonGroup/tests/radiobuttongroup.test.js
@@ -20,6 +20,19 @@ describe("RadioButtonGroup component", () => {
     expect(radiogroup.toJSON()).toMatchSnapshot();
   });
 
+  test("Matches snapshot (set name property)", () => {
+    const radiogroup = create(
+      <RadioButtonGroup
+        label="Test"
+        options={options}
+        value={1}
+        onChange={jest.fn()}
+        name="name"
+      />
+    );
+    expect(radiogroup.toJSON()).toMatchSnapshot();
+  });
+
   test("RadioButton click triggers change function and updates value", () => {
     let value = 1;
     const mockHandleChange = jest.fn(() => {

--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -45,6 +45,7 @@ const SlideAnimatedChild = ({
     },
     config: { mass: 1, tension: 210, friction: 26 },
     key: children[activeTabIndex]?.props?.children?.key,
+    delay: 100,
   });
   return slideTransition((contentStyle, item) => (
     <animated.div style={contentStyle} className={contentClassName}>

--- a/src/stories/RadioButton.stories.jsx
+++ b/src/stories/RadioButton.stories.jsx
@@ -9,7 +9,14 @@ const RadioButtonGroupObj = {
 
 export default RadioButtonGroupObj;
 
-const Template = ({ children, ...args }) => <RadioButtonGroup {...args} />;
+const Template = ({ children, ...args }) => {
+  const [selectedValue, setSelectedValue] = React.useState(args.value);
+  args.value = selectedValue;
+  args.onChange = (e) => {
+    setSelectedValue(e.value);
+  };
+  return <RadioButtonGroup {...args} />;
+};
 
 export const Basic = Template.bind({});
 Basic.args = {

--- a/src/stories/page.css
+++ b/src/stories/page.css
@@ -1,3 +1,9 @@
 body.sb-show-main {
   background: transparent !important;
 }
+
+#story--design-system-components-tabs--slide-animation {
+  position: relative;
+  overflow-x: hidden;
+  height: 5rem;
+}


### PR DESCRIPTION
Probably around updating react-spring the slide animation has broken. The content did not appear automatically, only after changing between tabs. This diff fixes it.
Also, update the `id` property of inputs in the Radio Button Group to be able to use more than one instance at a time.
Improved the Radio Button Group storybook too, now the controls are clickable.
