### PR TITLE
test(datepicker): use fake system time

### DIFF
--- a/src/components/Datepicker/DatepickerPad.module.css
+++ b/src/components/Datepicker/DatepickerPad.module.css
@@ -24,7 +24,13 @@
   border: 0;
   text-align: center;
   color: var(--text-color);
+  border: 1px solid transparent;
   background-color: var(--card-background);
+  outline: none;
+}
+
+.element:focus-visible {
+  border: 1px solid var(--color-primary);
 }
 
 .padRow {
@@ -36,7 +42,7 @@
 
 .disabled {
   cursor: default;
-  color: var(--btn-disabled-background-color);
+  color: var(--btn-disabled-text-color);
 }
 
 .selected {

--- a/src/components/Datepicker/DatepickerPad.module.css
+++ b/src/components/Datepicker/DatepickerPad.module.css
@@ -21,7 +21,6 @@
 .element {
   width: 60%;
   padding: 1rem;
-  border: 0;
   text-align: center;
   color: var(--text-color);
   border: 1px solid transparent;

--- a/src/components/Datepicker/stylesv2.module.css
+++ b/src/components/Datepicker/stylesv2.module.css
@@ -148,9 +148,9 @@
   background-color: rgba(255, 255, 255, 0.96);
 }
 
-.rmpPopup .rmpPopup.dark {
+.rmpPopup.dark {
   color: #fff;
-  background-color: rgba(50, 50, 50, 0.96);
+  background-color: var(--card-background);
 }
 
 @media (--sm-viewport) {
@@ -268,6 +268,10 @@
   .rmpPopup.light {
     border: 0.1rem solid #ccc;
     box-shadow: 0 0.1rem 0.5rem #ddd;
+  }
+  .rmpPopup.dark {
+    border: 0.1rem solid #717171;
+    box-shadow: 0 0.1rem 0.5rem rgba(113, 113, 113, 0.41);
   }
 
   .rmpPopup.light.range .rmpPad {

--- a/src/components/Datepicker/stylesv2.module.css
+++ b/src/components/Datepicker/stylesv2.module.css
@@ -273,7 +273,6 @@
     border: 0.1rem solid #717171;
     box-shadow: 0 0.1rem 0.5rem rgba(113, 113, 113, 0.41);
   }
-
   .rmpPopup.light.range .rmpPad {
     background-color: rgba(238, 238, 238, 0.9);
   }

--- a/src/components/Datepicker/test/datepickerv2.test.js
+++ b/src/components/Datepicker/test/datepickerv2.test.js
@@ -3,6 +3,7 @@ import DatePicker from "../Datepickerv2";
 import { render, screen } from "@testing-library/react";
 
 describe("Given DatePickerV2 component", () => {
+  jest.useFakeTimers().setSystemTime(new Date("2022-02-02"));
   const date = new Date();
   describe("when props are default", () => {
     it("should render date pads correctly", () => {
@@ -54,9 +55,7 @@ describe("Given DatePickerV2 component", () => {
     });
     it("should change year and move to max month if target month is greater than allowed", () => {
       // one year from now
-      const max = new Date(
-        new Date().setFullYear(date.getFullYear() + 1)
-      ).getTime();
+      const max = new Date("2023-01-02").getTime();
       render(<DatePicker maxTimestamp={max} />);
       screen.getByText(/pick a date/i).click();
       expect(
@@ -75,9 +74,7 @@ describe("Given DatePickerV2 component", () => {
   });
   describe("when pressing previous year arrow", () => {
     // previous year
-    const min = new Date(
-      new Date().setFullYear(date.getFullYear() - 1)
-    ).getTime();
+    const min = new Date("2021-02-02").getTime();
     it("should change year", () => {
       render(<DatePicker minTimestamp={min} />);
       screen.getByText(/pick a date/i).click();


### PR DESCRIPTION
This fixes the failing tests due non-deterministic behaviors on our
tests with datepicker v2 timer.